### PR TITLE
feat(create): mirror full operator catalogs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,13 @@ on:
       - main
 
 jobs:
+  # Static build and tests.
   test:
     strategy:
       matrix:
         go-version: [1.16.x]
         os: [ubuntu-latest, macos-latest]
-    
+
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
@@ -24,5 +25,23 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Makefile Go tasks
+    - name: Build and run tests
       run: make
+
+  # E2E tests.
+  e2e:
+    strategy:
+      matrix:
+        go-version: [1.16.x]
+
+    # TODO(estroz): get docker running on macOS, or use podman.
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run e2e tests
+      run: make test-e2e

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 coverage.out
 bundle*.tar.gz
 sha256sum.txt
+/test/operator-test.**
 
 # Logs.
 **/.openshift_bundle.log

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,11 @@
 GO := go
 
 .PHONY: all
-all: clean tidy test build
+all: clean tidy test-unit build
 
 .PHONY: build
 build: clean
 	$(GO) build -o bin/oc-bundle ./cmd/oc-bundle
-
-.PHONY: test
-test:
-	$(GO) test -coverprofile=coverage.out -race -count=1 ./pkg/...
 
 .PHONY: tidy
 tidy:
@@ -21,3 +17,13 @@ tidy:
 clean:
 	@rm -rf ./bin
 
+.PHONY: test-unit
+test-unit:
+	$(GO) test -coverprofile=coverage.out -race -count=1 ./pkg/...
+
+.PHONY: test-e2e
+test-e2e: test-e2e-operator
+
+.PHONY: test-e2e-operator
+test-e2e-operator: build
+	./test/test-operator.sh ./bin/oc-bundle

--- a/cmd/oc-bundle/create.go
+++ b/cmd/oc-bundle/create.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/RedHatGov/bundle/pkg/bundle/create"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/RedHatGov/bundle/pkg/bundle/create"
 )
 
 func newCreateCmd() *cobra.Command {
@@ -29,7 +30,7 @@ func newCreateFullCmd() *cobra.Command {
 			cleanup := setupFileHook(rootOpts.dir)
 			defer cleanup()
 			logrus.Infoln("Create full called")
-			err := create.CreateFull(rootOpts.dir)
+			err := create.CreateFull(rootOpts.dir, rootOpts.dryRun, rootOpts.skipTLS)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/oc-bundle/log.go
+++ b/cmd/oc-bundle/log.go
@@ -72,9 +72,11 @@ func (h *fileHook) Fire(entry *logrus.Entry) error {
 }
 
 func setupFileHook(baseDir string) func() {
-	/*if err := os.MkdirAll(baseDir, 0755); err != nil {
-		logrus.Fatal(errors.Wrap(err, "failed to create base directory for logs"))
-	}*/
+	if baseDir != "" && baseDir != "." {
+		if err := os.MkdirAll(baseDir, 0755); err != nil {
+			logrus.Fatal(errors.Wrap(err, "failed to create base directory for logs"))
+		}
+	}
 
 	logfile, err := os.OpenFile(filepath.Join(baseDir, ".openshift_bundle.log"), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {

--- a/cmd/oc-bundle/main.go
+++ b/cmd/oc-bundle/main.go
@@ -18,6 +18,8 @@ var (
 	rootOpts struct {
 		dir      string
 		logLevel string
+		dryRun   bool
+		skipTLS  bool
 	}
 )
 
@@ -62,8 +64,11 @@ func newRootCmd() *cobra.Command {
 		SilenceErrors:    true,
 		SilenceUsage:     true,
 	}
-	cmd.PersistentFlags().StringVar(&rootOpts.dir, "dir", ".", "assets directory")
+	cmd.PersistentFlags().StringVarP(&rootOpts.dir, "dir", "d", ".", "assets directory")
 	cmd.PersistentFlags().StringVar(&rootOpts.logLevel, "log-level", "info", "log level (e.g. \"debug | info | warn | error\")")
+	cmd.PersistentFlags().BoolVar(&rootOpts.dryRun, "dry-run", false, "print actions without mirroring images "+
+		"(experimental: only works for operator catalogs)")
+	cmd.PersistentFlags().BoolVar(&rootOpts.skipTLS, "skip-tls", false, "skip client-side TLS validation")
 	return cmd
 }
 

--- a/go.sum
+++ b/go.sum
@@ -77,7 +77,9 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/alexbrainman/sspi v0.0.0-20180613141037-e580b900e9f5/go.mod h1:976q2ETgjT2snVCf2ZaBnyBbVoPERGjUz+0sofzEfro=
+github.com/alicebob/sqlittle v1.4.0 h1:vgYt0nAjhdf/hg52MjKJ84g/uTzBPfrvI+VUBrIghxA=
 github.com/alicebob/sqlittle v1.4.0/go.mod h1:Co1L1qxHqCwf41puWhk2HOodojR0mcsAV4BIt8byZh8=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -1016,6 +1018,7 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/pkg/bundle/create/create.go
+++ b/pkg/bundle/create/create.go
@@ -1,32 +1,43 @@
 package create
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/RedHatGov/bundle/pkg/bundle"
 	"github.com/RedHatGov/bundle/pkg/config"
+	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
+	"github.com/RedHatGov/bundle/pkg/operator"
 )
 
 // CreateFull performs all tasks in creating full imagesets
-func CreateFull(rootDir string) error {
+func CreateFull(rootDir string, dryRun, insecure bool) error {
+	ctx := context.Background()
+
 	err := bundle.MakeCreateDirs(rootDir)
 	if err != nil {
-		logrus.Error(err)
 		return err
 	}
 	// Open Metadata
 	metadata, err := config.LoadMetadata(rootDir)
 	if err != nil {
-		logrus.Error(err)
 		return err
 	}
-	lastRun := metadata.PastMirrors[len(metadata.PastMirrors)-1]
-	logrus.Info(lastRun)
+
+	// TODO: this isn't the best way to handle metadata vs. no metadata.
+	// Needs refactoring.
+	var lastRun v1alpha1.PastMirror
+	if len(metadata.PastMirrors) != 0 {
+		lastRun = metadata.PastMirrors[len(metadata.PastMirrors)-1]
+		logrus.Debug(lastRun)
+	} else {
+		logrus.Debugf("no metadata found, creating full payload")
+	}
 
 	// Read the imageset-config.yaml
 	cfg, err := config.LoadConfig(rootDir)
 	if err != nil {
-		logrus.Error(err)
 		return err
 	}
 	logrus.Info(cfg)
@@ -37,12 +48,19 @@ func CreateFull(rootDir string) error {
 		}
 	}
 
-	/*if &config.Mirror.Operators != nil {
-	//GetOperators(*config, rootDir)
-	//}
-	//if &config.Mirror.Samples != nil {
-	//GetSamples(*config, rootDir)
-	//}*/
+	if len(cfg.Mirror.Operators) != 0 {
+		opts := operator.NewOperatorOptions()
+		opts.RootDestDir = rootDir
+		opts.DryRun = dryRun
+		opts.SkipTLS = insecure
+		if err := opts.Full(ctx, cfg); err != nil {
+			return err
+		}
+	}
+
+	if len(cfg.Mirror.Samples) != 0 {
+		logrus.Debugf("sample images full not implemented")
+	}
 
 	if len(cfg.Mirror.AdditionalImages) != 0 {
 		if err := bundle.GetAdditional(cfg, rootDir); err != nil {
@@ -54,10 +72,51 @@ func CreateFull(rootDir string) error {
 }
 
 // CreateDiff performs all tasks in creating differential imagesets
-//func CreateDiff(rootDir string) error {
-//    return err
-//}
+func CreateDiff(rootDir string) error {
+	_ = context.Background()
 
-//func downloadObjects() {
-//
-//}
+	err := bundle.MakeCreateDirs(rootDir)
+	if err != nil {
+		return err
+	}
+	// Open Metadata
+	metadata, err := config.LoadMetadata(rootDir)
+	if err != nil {
+		return err
+	}
+
+	// TODO: this isn't the best way to handle metadata vs. no metadata.
+	// Needs refactoring.
+	var lastRun v1alpha1.PastMirror
+	if len(metadata.PastMirrors) != 0 {
+		lastRun = metadata.PastMirrors[len(metadata.PastMirrors)-1]
+		logrus.Debug(lastRun)
+	} else {
+		logrus.Debugf("no metadata found, creating diff payload")
+	}
+
+	// Read the imageset-config.yaml
+	cfg, err := config.LoadConfig(rootDir)
+	if err != nil {
+		return err
+	}
+	logrus.Debug(cfg)
+
+	if len(cfg.Mirror.OCP.Channels) != 0 {
+		logrus.Debugf("release image diff not implemented")
+	}
+
+	if len(cfg.Mirror.Operators) != 0 {
+		logrus.Debugf("operator catalog image diff not implemented")
+	}
+
+	if len(cfg.Mirror.Samples) != 0 {
+		logrus.Debugf("sample images diff not implemented")
+	}
+
+	if len(cfg.Mirror.AdditionalImages) != 0 {
+		logrus.Debugf("additional images diff not implemented")
+	}
+
+	return err
+}

--- a/pkg/bundle/init.go
+++ b/pkg/bundle/init.go
@@ -2,6 +2,7 @@ package bundle
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 )
@@ -32,20 +33,21 @@ func ValidateCreateDir(rootDir string) error {
 */
 func MakeCreateDirs(rootDir string) error {
 	paths := []string{
-		"/bundle/publish",
-		"/bundle/v2",
-		"/src/publish",
-		"/src/v2",
+		filepath.Join("bundle", "publish"),
+		filepath.Join("bundle", "v2"),
+		filepath.Join("src", "publish"),
+		filepath.Join("src", "v2"),
 	}
 	for _, p := range paths {
-		if _, err := os.Stat(rootDir + p); os.IsNotExist(err) {
-			err := os.MkdirAll(rootDir+p, os.ModePerm)
+		dir := filepath.Join(rootDir, p)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			logrus.Infof("Creating directory: %v", dir)
+			err := os.MkdirAll(dir, os.ModePerm)
 			if err != nil {
-				logrus.Errorln(err)
+				return err
 			}
-			logrus.Infof("Creating directory: %v", rootDir+p)
 		} else {
-			logrus.Infof("Found %v", rootDir+p)
+			logrus.Infof("Found: %v", dir)
 		}
 	}
 	return nil

--- a/pkg/bundle/operator.go
+++ b/pkg/bundle/operator.go
@@ -1,1 +1,0 @@
-package bundle

--- a/pkg/bundle/release.go
+++ b/pkg/bundle/release.go
@@ -24,6 +24,10 @@ import (
 //   "github.com/openshift/cluster-version-operator/pkg/cincinnati"
 // )
 
+const (
+	UpdateUrl string = "https://api.openshift.com/api/upgrades_info/v1/graph"
+)
+
 // This file is for managing OCP release related tasks
 
 const updateUrl string = "https://api.openshift.com/api/upgrades_info/v1/graph"

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -69,7 +69,7 @@ func LoadMetadata(rootDir string) (metadata v1alpha1.Metadata, err error) {
 }
 
 func getTypeMeta(data []byte) (typeMeta metav1.TypeMeta, err error) {
-	if err := yaml.UnmarshalStrict(data, &typeMeta); err != nil {
+	if err := yaml.Unmarshal(data, &typeMeta); err != nil {
 		return typeMeta, fmt.Errorf("get type meta: %v", err)
 	}
 	return typeMeta, nil

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -1,0 +1,152 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	imgreference "github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc/pkg/cli/admin/catalog"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
+	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
+	imgmirror "github.com/openshift/oc/pkg/cli/image/mirror"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
+)
+
+type OperatorOptions struct {
+	RootDestDir string
+	DryRun      bool
+	Cleanup     bool
+	SkipTLS     bool
+}
+
+func NewOperatorOptions() *OperatorOptions {
+	return &OperatorOptions{}
+}
+
+func (o *OperatorOptions) mktempDir() (string, error) {
+	dir := filepath.Join(o.RootDestDir, fmt.Sprintf("operators.%d", time.Now().Unix()))
+	return dir, os.MkdirAll(dir, os.ModePerm)
+}
+
+// Full mirrors each catalog image in its entirety to the <RootDestDir>/src directory.
+func (o *OperatorOptions) Full(_ context.Context, cfg v1alpha1.ImageSetConfiguration) (err error) {
+
+	tmp, err := o.mktempDir()
+	if err != nil {
+		return err
+	}
+	if o.Cleanup {
+		defer func() {
+			if err := os.RemoveAll(tmp); err != nil {
+				logrus.Error(err)
+			}
+		}()
+	}
+
+	for _, ctlg := range cfg.Mirror.Operators {
+		stream := genericclioptions.IOStreams{
+			In:     os.Stdin,
+			Out:    os.Stdout,
+			ErrOut: os.Stderr,
+		}
+		opts := catalog.NewMirrorCatalogOptions(stream)
+		opts.DryRun = o.DryRun
+		opts.FileDir = filepath.Join(o.RootDestDir, "src")
+		opts.ManifestDir = filepath.Join(tmp, fmt.Sprintf("manifests-%s-%d", opts.SourceRef.Ref.Name, time.Now().Unix()))
+		opts.SecurityOptions.Insecure = o.SkipTLS
+
+		ref, err := imgreference.Parse(ctlg.Catalog)
+		if err != nil {
+			return err
+		}
+		ref = ref.DockerClientDefaults()
+
+		args := []string{
+			// The source is the catalog image itself.
+			ctlg.Catalog,
+			// The destination is within <RootDestDir>/src/v2/<image-name>.
+			refToFileScheme(ref),
+		}
+		if err := opts.Complete(&cobra.Command{}, args); err != nil {
+			return err
+		}
+
+		// TODO(estroz): the mirrorer needs to be set after Complete() is called
+		// because the default ImageMirrorer does not set FileDir from opts.
+		// This isn't great because the default ImageMirrorer is a closure
+		// and may contain configuration that gets overridden here.
+		if opts.ImageMirrorer, err = newMirrorerFunc(opts); err != nil {
+			return err
+		}
+
+		if err := opts.Validate(); err != nil {
+			return err
+		}
+
+		if err := opts.Run(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Input refs to the mirror library must be prefixed with "file://" if a local file ref.
+func refToFileScheme(ref imgreference.DockerImageReference) string {
+	return "file://" + filepath.Join(ref.Namespace, ref.Name)
+}
+
+// Copied from https://github.com/openshift/oc/blob/4df50be4d929ce036c4f07893c07a1782eadbbba/pkg/cli/admin/catalog/mirror.go#L284-L313
+// Hoping this can be temporary, and `oc adm mirror catalog` libs support index.yaml direct mirroring.
+
+func newMirrorerFunc(opts *catalog.MirrorCatalogOptions) (catalog.ImageMirrorerFunc, error) {
+	allmanifestsFilter := imagemanifest.FilterOptions{FilterByOS: ".*"}
+	if err := allmanifestsFilter.Validate(); err != nil {
+		return nil, err
+	}
+
+	return func(mapping map[imagesource.TypedImageReference]imagesource.TypedImageReference) error {
+		mappings := []imgmirror.Mapping{}
+		for from, to := range mapping {
+			mappings = append(mappings, imgmirror.Mapping{
+				Source:      from,
+				Destination: to,
+			})
+		}
+
+		a := imgmirror.NewMirrorImageOptions(opts.IOStreams)
+		a.SkipMissing = true
+		a.ContinueOnError = true
+		a.DryRun = opts.DryRun
+		a.SecurityOptions = opts.SecurityOptions
+		a.FileDir = opts.FileDir
+		// because images in the catalog are statically referenced by digest,
+		// we do not allow filtering for mirroring. this may change if sparse manifestlists are allowed
+		// by registries, or if multi-arch management moves into images that can be rewritten on mirror (i.e. the bundle
+		// images themselves, not the images referenced inside of the bundle images).
+		a.FilterOptions = allmanifestsFilter
+		a.ParallelOptions = opts.ParallelOptions
+		a.KeepManifestList = true
+		a.Mappings = mappings
+		a.SkipMultipleScopes = true
+
+		if err := a.Validate(); err != nil {
+			fmt.Fprintf(opts.IOStreams.ErrOut, "error configuring image mirroring: %v\n", err)
+			return nil
+		}
+
+		if err := a.Run(); err != nil {
+			fmt.Fprintf(opts.IOStreams.ErrOut, "error mirroring image: %v\n", err)
+			return nil
+		}
+
+		return nil
+	}, nil
+}

--- a/test/operator/setup-testdata.sh
+++ b/test/operator/setup-testdata.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -eu
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DATA_DIR="${1:?data dir is required}"
+OUTPUT_DIR="${2:?output dir is required}"
+REGISTRY="localhost:5000"
+CATALOGNAMESPACE="test-catalogs"
+REGISTRY_CATALOGNAMESPACE="${REGISTRY}/${CATALOGNAMESPACE}"
+
+function setup() {
+  echo -e "\nSetting up test directory in $DATA_DIR"
+  cp -r "${DIR}/testdata/bundles/"* "$DATA_DIR"
+  mkdir -p "${DATA_DIR}/index"
+  cp -r "${DIR}/testdata/indices/latest/"* "${DATA_DIR}/index/"
+  find "$DATA_DIR" -type f -exec sed -i -E 's@REGISTRY_ONLY@'"$REGISTRY"'@g' {} \;
+  mkdir -p "${OUTPUT_DIR}"
+  cp "${DIR}/testdata/configs/latest/imageset-config.yaml" "$OUTPUT_DIR/"
+  find "$DATA_DIR" -type f -exec sed -i -E 's@REGISTRY_CATALOGNAMESPACE@'"$REGISTRY_CATALOGNAMESPACE"'@g' {} \;
+}
+
+function build_push_bundles() {
+  echo -e "\nBuilding and pushing bundle images"
+  for d in `find "${DATA_DIR}" -maxdepth 1 -name *-bundle-*`; do
+    local img="${REGISTRY}/$(basename $d | cut -d- -f1)-operator/$(basename $d | cut -d- -f1-2):$(basename $d | cut -d- -f3)"
+    pushd $d
+    docker build -t $img -f bundle.Dockerfile .
+    docker push $img
+    popd
+  done
+}
+
+function build_push_related_images() {
+  echo -e "\nBuilding and pushing related images"
+  for img in `yq eval '.relatedImages[].image' "${DATA_DIR}/index/index.yaml" --no-doc`; do
+    local tmp=$(mktemp -d ${DATA_DIR}/bundle-image.XXXXX)
+    pushd "$tmp"
+    echo -e "#!/bin/sh\n\necho \"relatedImage: $img\"" > run.sh
+    chmod +x run.sh
+    cat <<EOF > Dockerfile
+FROM alpine
+COPY run.sh /
+ENTRYPOINT ["/run.sh"]
+EOF
+    docker build -t $img -f Dockerfile .
+    docker push $img
+    popd
+    rm -rf "$tmp"
+  done
+}
+
+# TODO(estroz): consider regenerating index.yaml with opm.
+function build_push_catalog() {
+  echo -e "\nBuilding and pushing catalog image"
+  local img="${REGISTRY_CATALOGNAMESPACE}/test-catalog:latest"
+  pushd "${DATA_DIR}/index"
+  docker build -t $img -f index.Dockerfile .
+  docker push $img
+  popd
+}
+
+setup
+build_push_bundles
+build_push_related_images
+build_push_catalog

--- a/test/operator/testdata/bundles/bar-bundle-v0.1.0/bundle.Dockerfile
+++ b/test/operator/testdata/bundles/bar-bundle-v0.1.0/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=bar
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/test/operator/testdata/bundles/bar-bundle-v0.1.0/manifests/bar.csv.yaml
+++ b/test/operator/testdata/bundles/bar-bundle-v0.1.0/manifests/bar.csv.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: bar.v0.1.0
+spec:
+  customresourcedefinitions:
+    owned:
+      - group: test.bar
+        version: v1alpha1
+        kind: Bar
+        name: bars.test.bar
+  version: 0.1.0
+  relatedImages:
+    - name: operator
+      image: REGISTRY_ONLY/bar-operator/bar:v0.1.0

--- a/test/operator/testdata/bundles/bar-bundle-v0.1.0/manifests/bars.test.bar.crd.yaml
+++ b/test/operator/testdata/bundles/bar-bundle-v0.1.0/manifests/bars.test.bar.crd.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bars.test.bar
+spec:
+  group: test.bar
+  names:
+    kind: Bar
+    plural: bars
+  versions:
+    - name: v1alpha1

--- a/test/operator/testdata/bundles/bar-bundle-v0.1.0/metadata/annotations.yaml
+++ b/test/operator/testdata/bundles/bar-bundle-v0.1.0/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: bar
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha

--- a/test/operator/testdata/bundles/bar-bundle-v0.2.0/bundle.Dockerfile
+++ b/test/operator/testdata/bundles/bar-bundle-v0.2.0/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=bar
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/test/operator/testdata/bundles/bar-bundle-v0.2.0/manifests/bar.csv.yaml
+++ b/test/operator/testdata/bundles/bar-bundle-v0.2.0/manifests/bar.csv.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: bar.v0.2.0
+  annotations:
+    olm.skipRange: <0.2.0
+spec:
+  customresourcedefinitions:
+    owned:
+      - group: test.bar
+        version: v1alpha1
+        kind: Bar
+        name: bars.test.bar
+  version: 0.2.0
+  skips:
+    - bar.v0.1.0
+  relatedImages:
+    - name: operator
+      image: REGISTRY_ONLY/bar-operator/bar:v0.2.0

--- a/test/operator/testdata/bundles/bar-bundle-v0.2.0/manifests/bars.test.bar.crd.yaml
+++ b/test/operator/testdata/bundles/bar-bundle-v0.2.0/manifests/bars.test.bar.crd.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bars.test.bar
+spec:
+  group: test.bar
+  names:
+    kind: Bar
+    plural: bars
+  versions:
+    - name: v1alpha1

--- a/test/operator/testdata/bundles/bar-bundle-v0.2.0/metadata/annotations.yaml
+++ b/test/operator/testdata/bundles/bar-bundle-v0.2.0/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: bar
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha

--- a/test/operator/testdata/bundles/bar-bundle-v1.0.0/bundle.Dockerfile
+++ b/test/operator/testdata/bundles/bar-bundle-v1.0.0/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=bar
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/test/operator/testdata/bundles/bar-bundle-v1.0.0/manifests/bar.csv.yaml
+++ b/test/operator/testdata/bundles/bar-bundle-v1.0.0/manifests/bar.csv.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: bar.v1.0.0
+spec:
+  customresourcedefinitions:
+    owned:
+      - group: test.bar
+        version: v1alpha1
+        kind: Bar
+        name: bars.test.bar
+      - group: test.bar
+        version: v1
+        kind: Bar
+        name: bars.test.bar
+  version: 1.0.0
+  replaces: bar.v0.2.0
+  relatedImages:
+    - name: operator
+      image: REGISTRY_ONLY/bar-operator/bar:v1.0.0

--- a/test/operator/testdata/bundles/bar-bundle-v1.0.0/manifests/bars.test.bar.crd.yaml
+++ b/test/operator/testdata/bundles/bar-bundle-v1.0.0/manifests/bars.test.bar.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bars.test.bar
+spec:
+  group: test.bar
+  names:
+    kind: Bar
+    plural: bars
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: true

--- a/test/operator/testdata/bundles/bar-bundle-v1.0.0/metadata/annotations.yaml
+++ b/test/operator/testdata/bundles/bar-bundle-v1.0.0/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: bar
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable

--- a/test/operator/testdata/bundles/baz-bundle-v1.0.0/bundle.Dockerfile
+++ b/test/operator/testdata/bundles/baz-bundle-v1.0.0/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=baz
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/test/operator/testdata/bundles/baz-bundle-v1.0.0/manifests/baz.csv.yaml
+++ b/test/operator/testdata/bundles/baz-bundle-v1.0.0/manifests/baz.csv.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: baz.v1.0.0
+spec:
+  customresourcedefinitions:
+    owned:
+      - group: test.baz
+        version: v1
+        kind: Baz
+        name: bazs.test.baz
+  version: 1.0.0
+  relatedImages:
+    - name: operator
+      image: REGISTRY_ONLY/baz-operator/baz:v1.0.0

--- a/test/operator/testdata/bundles/baz-bundle-v1.0.0/manifests/bazs.test.baz.crd.yaml
+++ b/test/operator/testdata/bundles/baz-bundle-v1.0.0/manifests/bazs.test.baz.crd.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bazs.test.baz
+spec:
+  group: test.baz
+  names:
+    kind: Baz
+    plural: bazs
+  versions:
+    - name: v1

--- a/test/operator/testdata/bundles/baz-bundle-v1.0.0/metadata/annotations.yaml
+++ b/test/operator/testdata/bundles/baz-bundle-v1.0.0/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: baz
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable

--- a/test/operator/testdata/bundles/baz-bundle-v1.0.1/bundle.Dockerfile
+++ b/test/operator/testdata/bundles/baz-bundle-v1.0.1/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=baz
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/test/operator/testdata/bundles/baz-bundle-v1.0.1/manifests/baz.csv.yaml
+++ b/test/operator/testdata/bundles/baz-bundle-v1.0.1/manifests/baz.csv.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: baz.v1.0.1
+  annotations:
+    olm.skipRange: <1.0.1
+spec:
+  customresourcedefinitions:
+    owned:
+      - group: test.baz
+        version: v1
+        kind: Baz
+        name: bazs.test.baz
+  version: 1.0.1
+  skips:
+    - baz.v1.0.0
+  relatedImages:
+    - name: operator
+      image: REGISTRY_ONLY/baz-operator/baz:v1.0.1

--- a/test/operator/testdata/bundles/baz-bundle-v1.0.1/manifests/bazs.test.baz.crd.yaml
+++ b/test/operator/testdata/bundles/baz-bundle-v1.0.1/manifests/bazs.test.baz.crd.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bazs.test.baz
+spec:
+  group: test.baz
+  names:
+    kind: Baz
+    plural: bazs
+  versions:
+    - name: v1

--- a/test/operator/testdata/bundles/baz-bundle-v1.0.1/metadata/annotations.yaml
+++ b/test/operator/testdata/bundles/baz-bundle-v1.0.1/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: baz
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable

--- a/test/operator/testdata/bundles/baz-bundle-v1.1.0/bundle.Dockerfile
+++ b/test/operator/testdata/bundles/baz-bundle-v1.1.0/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=baz
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/test/operator/testdata/bundles/baz-bundle-v1.1.0/manifests/baz.csv.yaml
+++ b/test/operator/testdata/bundles/baz-bundle-v1.1.0/manifests/baz.csv.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: baz.v1.1.0
+spec:
+  customresourcedefinitions:
+    owned:
+      - group: test.baz
+        version: v1
+        kind: Baz
+        name: bazs.test.baz
+  version: 1.1.0
+  replaces: baz.v1.0.0
+  relatedImages:
+    - name: operator
+      image: REGISTRY_ONLY/baz-operator/baz:v1.1.0

--- a/test/operator/testdata/bundles/baz-bundle-v1.1.0/manifests/bazs.test.baz.crd.yaml
+++ b/test/operator/testdata/bundles/baz-bundle-v1.1.0/manifests/bazs.test.baz.crd.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bazs.test.baz
+spec:
+  group: test.baz
+  names:
+    kind: Baz
+    plural: bazs
+  versions:
+    - name: v1

--- a/test/operator/testdata/bundles/baz-bundle-v1.1.0/metadata/annotations.yaml
+++ b/test/operator/testdata/bundles/baz-bundle-v1.1.0/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: baz
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable

--- a/test/operator/testdata/bundles/foo-bundle-v0.1.0/bundle.Dockerfile
+++ b/test/operator/testdata/bundles/foo-bundle-v0.1.0/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=foo
+LABEL operators.operatorframework.io.bundle.channels.v1=beta
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/test/operator/testdata/bundles/foo-bundle-v0.1.0/manifests/foo.csv.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.1.0/manifests/foo.csv.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: foo.v0.1.0
+  annotations:
+    olm.skipRange: <0.1.0
+spec:
+  displayName: "Foo Operator"
+  customresourcedefinitions:
+    owned:
+      - group: test.foo
+        version: v1
+        kind: Foo
+        name: foos.test.foo
+  version: 0.1.0
+  relatedImages:
+    - name: operator
+      image: REGISTRY_ONLY/foo-operator/foo:v0.1.0

--- a/test/operator/testdata/bundles/foo-bundle-v0.1.0/manifests/foos.test.foo.crd.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.1.0/manifests/foos.test.foo.crd.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.test.foo
+spec:
+  group: test.foo
+  names:
+    kind: Foo
+    plural: foos
+  versions:
+    - name: v1

--- a/test/operator/testdata/bundles/foo-bundle-v0.1.0/metadata/annotations.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.1.0/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: foo
+  operators.operatorframework.io.bundle.channels.v1: beta
+  operators.operatorframework.io.bundle.channel.default.v1: beta

--- a/test/operator/testdata/bundles/foo-bundle-v0.1.0/metadata/dependencies.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.1.0/metadata/dependencies.yaml
@@ -1,0 +1,11 @@
+---
+dependencies:
+  - type: olm.package
+    value:
+      packageName: bar
+      version: <0.1.0
+  - type: olm.gvk
+    value:
+      group: "test.bar"
+      version: "v1alpha1"
+      kind: "Bar"

--- a/test/operator/testdata/bundles/foo-bundle-v0.2.0/bundle.Dockerfile
+++ b/test/operator/testdata/bundles/foo-bundle-v0.2.0/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=foo
+LABEL operators.operatorframework.io.bundle.channels.v1=beta
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/test/operator/testdata/bundles/foo-bundle-v0.2.0/manifests/foo.csv.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.2.0/manifests/foo.csv.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: foo.v0.2.0
+  annotations:
+    olm.skipRange: <0.2.0
+spec:
+  displayName: "Foo Operator"
+  customresourcedefinitions:
+    owned:
+      - group: test.foo
+        version: v1
+        kind: Foo
+        name: foos.test.foo
+  version: 0.2.0
+  replaces: foo.v0.1.0
+  skips:
+    - foo.v0.1.1
+    - foo.v0.1.2
+  relatedImages:
+    - name: operator
+      image: REGISTRY_ONLY/foo-operator/foo:v0.2.0

--- a/test/operator/testdata/bundles/foo-bundle-v0.2.0/manifests/foos.test.foo.crd.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.2.0/manifests/foos.test.foo.crd.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.test.foo
+spec:
+  group: test.foo
+  names:
+    kind: Foo
+    plural: foos
+  versions:
+    - name: v1

--- a/test/operator/testdata/bundles/foo-bundle-v0.2.0/metadata/annotations.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.2.0/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: foo
+  operators.operatorframework.io.bundle.channels.v1: beta,stable
+  operators.operatorframework.io.bundle.channel.default.v1: beta

--- a/test/operator/testdata/bundles/foo-bundle-v0.2.0/metadata/dependencies.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.2.0/metadata/dependencies.yaml
@@ -1,0 +1,11 @@
+---
+dependencies:
+  - type: olm.package
+    value:
+      packageName: bar
+      version: <0.1.0
+  - type: olm.gvk
+    value:
+      group: "test.bar"
+      version: "v1alpha1"
+      kind: "Bar"

--- a/test/operator/testdata/bundles/foo-bundle-v0.3.0/bundle.Dockerfile
+++ b/test/operator/testdata/bundles/foo-bundle-v0.3.0/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=foo
+LABEL operators.operatorframework.io.bundle.channels.v1=beta
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/test/operator/testdata/bundles/foo-bundle-v0.3.0/manifests/foo.csv.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.3.0/manifests/foo.csv.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: foo.v0.3.0
+spec:
+  customresourcedefinitions:
+    owned:
+      - group: test.foo
+        version: v1
+        kind: Foo
+        name: foos.test.foo
+      - group: test.foo
+        version: v2
+        kind: Foo
+        name: foos.test.foo
+  version: 0.3.0
+  replaces: foo.v0.2.0
+  relatedImages:
+    - name: operator
+      image: REGISTRY_ONLY/foo-operator/foo:v0.3.0

--- a/test/operator/testdata/bundles/foo-bundle-v0.3.0/manifests/foos.test.foo.crd.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.3.0/manifests/foos.test.foo.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.test.foo
+spec:
+  group: test.foo
+  names:
+    kind: Foo
+    plural: foos
+  versions:
+    - name: v1
+      served: true
+      storage: false
+    - name: v2
+      served: true
+      storage: true

--- a/test/operator/testdata/bundles/foo-bundle-v0.3.0/metadata/annotations.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.3.0/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: foo
+  operators.operatorframework.io.bundle.channels.v1: beta
+  operators.operatorframework.io.bundle.channel.default.v1: beta

--- a/test/operator/testdata/bundles/foo-bundle-v0.3.0/metadata/dependencies.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.3.0/metadata/dependencies.yaml
@@ -1,0 +1,11 @@
+---
+dependencies:
+  - type: olm.package
+    value:
+      packageName: bar
+      version: <0.2.0
+  - type: olm.gvk
+    value:
+      group: "test.bar"
+      version: "v1alpha1"
+      kind: "Bar"

--- a/test/operator/testdata/bundles/foo-bundle-v0.3.1/bundle.Dockerfile
+++ b/test/operator/testdata/bundles/foo-bundle-v0.3.1/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=foo
+LABEL operators.operatorframework.io.bundle.channels.v1=beta
+
+# Copy files to locations specified by labels.
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/test/operator/testdata/bundles/foo-bundle-v0.3.1/manifests/foo.csv.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.3.1/manifests/foo.csv.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: foo.v0.3.1
+spec:
+  customresourcedefinitions:
+    owned:
+      - group: test.foo
+        version: v1
+        kind: Foo
+        name: foos.test.foo
+      - group: test.foo
+        version: v2
+        kind: Foo
+        name: foos.test.foo
+  version: 0.3.1
+  replaces: foo.v0.2.0
+  skips:
+    - foo.v0.3.0
+  relatedImages:
+    - name: operator
+      image: REGISTRY_ONLY/foo-operator/foo:v0.3.1

--- a/test/operator/testdata/bundles/foo-bundle-v0.3.1/manifests/foos.test.foo.crd.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.3.1/manifests/foos.test.foo.crd.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.test.foo
+spec:
+  group: test.foo
+  names:
+    kind: Foo
+    plural: foos
+  versions:
+    - name: v1
+      served: true
+      storage: false
+    - name: v2
+      served: true
+      storage: true

--- a/test/operator/testdata/bundles/foo-bundle-v0.3.1/metadata/annotations.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.3.1/metadata/annotations.yaml
@@ -1,0 +1,4 @@
+annotations:
+  operators.operatorframework.io.bundle.package.v1: foo
+  operators.operatorframework.io.bundle.channels.v1: beta
+  operators.operatorframework.io.bundle.channel.default.v1: beta

--- a/test/operator/testdata/bundles/foo-bundle-v0.3.1/metadata/dependencies.yaml
+++ b/test/operator/testdata/bundles/foo-bundle-v0.3.1/metadata/dependencies.yaml
@@ -1,0 +1,11 @@
+---
+dependencies:
+  - type: olm.package
+    value:
+      packageName: bar
+      version: <0.2.0
+  - type: olm.gvk
+    value:
+      group: "test.bar"
+      version: "v1alpha1"
+      kind: "Bar"

--- a/test/operator/testdata/configs/latest/imageset-config.yaml
+++ b/test/operator/testdata/configs/latest/imageset-config.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: tmp-redhatgov.com/v1alpha1
+kind: ImageSetConfiguration
+mirror:
+  operators:
+  - catalog: REGISTRY_CATALOGNAMESPACE/test-catalog:latest

--- a/test/operator/testdata/indices/latest/index.Dockerfile
+++ b/test/operator/testdata/indices/latest/index.Dockerfile
@@ -1,0 +1,14 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM quay.io/operator-framework/upstream-opm-builder
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs"]
+
+# Copy declarative config root into image at /configs
+ADD index /configs
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/test/operator/testdata/indices/latest/index/index.yaml
+++ b/test/operator/testdata/indices/latest/index/index.yaml
@@ -1,0 +1,362 @@
+---
+defaultChannel: stable
+name: bar
+schema: olm.package
+---
+image: REGISTRY_ONLY/bar-operator/bar-bundle:v0.1.0
+name: bar.v0.1.0
+package: bar
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhcnMudGVzdC5iYXIifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmFyIiwibmFtZXMiOnsia2luZCI6IkJhciIsInBsdXJhbCI6ImJhcnMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MWFscGhhMSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhci52MC4xLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuYmFyIiwia2luZCI6IkJhciIsIm5hbWUiOiJiYXJzLnRlc3QuYmFyIiwidmVyc2lvbiI6InYxYWxwaGExIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Jhci1vcGVyYXRvci9iYXI6djAuMS4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJ2ZXJzaW9uIjoiMC4xLjAifX0=
+- type: olm.channel
+  value:
+    name: alpha
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 0.1.0
+relatedImages:
+- image: REGISTRY_ONLY/bar-operator/bar:v0.1.0
+  name: operator
+schema: olm.bundle
+---
+image: REGISTRY_ONLY/bar-operator/bar-bundle:v0.2.0
+name: bar.v0.2.0
+package: bar
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhcnMudGVzdC5iYXIifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmFyIiwibmFtZXMiOnsia2luZCI6IkJhciIsInBsdXJhbCI6ImJhcnMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MWFscGhhMSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMi4wIn0sIm5hbWUiOiJiYXIudjAuMi4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmJhciIsImtpbmQiOiJCYXIiLCJuYW1lIjoiYmFycy50ZXN0LmJhciIsInZlcnNpb24iOiJ2MWFscGhhMSJ9XX0sInJlbGF0ZWRJbWFnZXMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9iYXItb3BlcmF0b3IvYmFyOnYwLjIuMCIsIm5hbWUiOiJvcGVyYXRvciJ9XSwic2tpcHMiOlsiYmFyLnYwLjEuMCJdLCJ2ZXJzaW9uIjoiMC4yLjAifX0=
+- type: olm.channel
+  value:
+    name: alpha
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 0.2.0
+- type: olm.skipRange
+  value: <0.2.0
+- type: olm.skips
+  value: bar.v0.1.0
+relatedImages:
+- image: REGISTRY_ONLY/bar-operator/bar:v0.2.0
+  name: operator
+schema: olm.bundle
+---
+image: REGISTRY_ONLY/bar-operator/bar-bundle:v1.0.0
+name: bar.v1.0.0
+package: bar
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhcnMudGVzdC5iYXIifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmFyIiwibmFtZXMiOnsia2luZCI6IkJhciIsInBsdXJhbCI6ImJhcnMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MWFscGhhMSIsInNlcnZlZCI6dHJ1ZSwic3RvcmFnZSI6ZmFsc2V9LHsibmFtZSI6InYxIiwic2VydmVkIjp0cnVlLCJzdG9yYWdlIjp0cnVlfV19fQ==
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhci52MS4wLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuYmFyIiwia2luZCI6IkJhciIsIm5hbWUiOiJiYXJzLnRlc3QuYmFyIiwidmVyc2lvbiI6InYxYWxwaGExIn0seyJncm91cCI6InRlc3QuYmFyIiwia2luZCI6IkJhciIsIm5hbWUiOiJiYXJzLnRlc3QuYmFyIiwidmVyc2lvbiI6InYxIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Jhci1vcGVyYXRvci9iYXI6djEuMC4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJyZXBsYWNlcyI6ImJhci52MC4yLjAiLCJ2ZXJzaW9uIjoiMS4wLjAifX0=
+- type: olm.channel
+  value:
+    name: alpha
+    replaces: bar.v0.2.0
+- type: olm.channel
+  value:
+    name: stable
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1
+- type: olm.gvk
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: bar
+    version: 1.0.0
+relatedImages:
+- image: REGISTRY_ONLY/bar-operator/bar:v1.0.0
+  name: operator
+schema: olm.bundle
+---
+defaultChannel: stable
+name: baz
+schema: olm.package
+---
+image: REGISTRY_ONLY/baz-operator/baz-bundle:v1.0.0
+name: baz.v1.0.0
+package: baz
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhenMudGVzdC5iYXoifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmF6IiwibmFtZXMiOnsia2luZCI6IkJheiIsInBsdXJhbCI6ImJhenMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhei52MS4wLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuYmF6Iiwia2luZCI6IkJheiIsIm5hbWUiOiJiYXpzLnRlc3QuYmF6IiwidmVyc2lvbiI6InYxIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Jhei1vcGVyYXRvci9iYXo6djEuMC4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJ2ZXJzaW9uIjoiMS4wLjAifX0=
+- type: olm.channel
+  value:
+    name: stable
+- type: olm.gvk
+  value:
+    group: test.baz
+    kind: Baz
+    version: v1
+- type: olm.package
+  value:
+    packageName: baz
+    version: 1.0.0
+- type: olm.skipRange
+  value: <1.0.0
+relatedImages:
+- image: REGISTRY_ONLY/baz-operator/baz:v1.0.0
+  name: operator
+schema: olm.bundle
+---
+image: REGISTRY_ONLY/baz-operator/baz-bundle:v1.0.1
+name: baz.v1.0.1
+package: baz
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhenMudGVzdC5iYXoifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmF6IiwibmFtZXMiOnsia2luZCI6IkJheiIsInBsdXJhbCI6ImJhenMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzEuMC4xIn0sIm5hbWUiOiJiYXoudjEuMC4xIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmJheiIsImtpbmQiOiJCYXoiLCJuYW1lIjoiYmF6cy50ZXN0LmJheiIsInZlcnNpb24iOiJ2MSJ9XX0sInJlbGF0ZWRJbWFnZXMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9iYXotb3BlcmF0b3IvYmF6OnYxLjAuMSIsIm5hbWUiOiJvcGVyYXRvciJ9XSwic2tpcHMiOlsiYmF6LnYxLjAuMCJdLCJ2ZXJzaW9uIjoiMS4wLjEifX0=
+- type: olm.channel
+  value:
+    name: stable
+    replaces: baz.v1.0.0
+- type: olm.gvk
+  value:
+    group: test.baz
+    kind: Baz
+    version: v1
+- type: olm.package
+  value:
+    packageName: baz
+    version: 1.0.1
+- type: olm.skipRange
+  value: <1.0.0
+relatedImages:
+- image: REGISTRY_ONLY/baz-operator/baz:v1.0.1
+  name: operator
+schema: olm.bundle
+---
+image: REGISTRY_ONLY/baz-operator/baz-bundle:v1.1.0
+name: baz.v1.1.0
+package: baz
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhenMudGVzdC5iYXoifSwic3BlYyI6eyJncm91cCI6InRlc3QuYmF6IiwibmFtZXMiOnsia2luZCI6IkJheiIsInBsdXJhbCI6ImJhenMifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImJhei52MS4xLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuYmF6Iiwia2luZCI6IkJheiIsIm5hbWUiOiJiYXpzLnRlc3QuYmF6IiwidmVyc2lvbiI6InYxIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Jhei1vcGVyYXRvci9iYXo6djEuMS4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJyZXBsYWNlcyI6ImJhei52MS4wLjAiLCJ2ZXJzaW9uIjoiMS4xLjAifX0=
+- type: olm.channel
+  value:
+    name: stable
+    replaces: baz.v1.0.0
+- type: olm.gvk
+  value:
+    group: test.baz
+    kind: Baz
+    version: v1
+- type: olm.package
+  value:
+    packageName: baz
+    version: 1.1.0
+- type: olm.skips
+  value: baz.v1.0.1
+relatedImages:
+- image: REGISTRY_ONLY/baz-operator/baz:v1.1.0
+  name: operator
+schema: olm.bundle
+---
+defaultChannel: beta
+name: foo
+schema: olm.package
+---
+image: REGISTRY_ONLY/foo-operator/foo-bundle:v0.1.0
+name: foo.v0.1.0
+package: foo
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMS4wIn0sIm5hbWUiOiJmb28udjAuMS4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmZvbyIsImtpbmQiOiJGb28iLCJuYW1lIjoiZm9vcy50ZXN0LmZvbyIsInZlcnNpb24iOiJ2MSJ9XX0sInJlbGF0ZWRJbWFnZXMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vOnYwLjEuMCIsIm5hbWUiOiJvcGVyYXRvciJ9XSwidmVyc2lvbiI6IjAuMS4wIn19
+- type: olm.channel
+  value:
+    name: beta
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.1.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.1.0
+- type: olm.skipRange
+  value: <0.1.0
+relatedImages:
+- image: REGISTRY_ONLY/foo-operator/foo:v0.1.0
+  name: operator
+schema: olm.bundle
+---
+image: REGISTRY_ONLY/foo-operator/foo-bundle:v0.2.0
+name: foo.v0.2.0
+package: foo
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSJ9XX19
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsiYW5ub3RhdGlvbnMiOnsib2xtLnNraXBSYW5nZSI6Ilx1MDAzYzAuMi4wIn0sIm5hbWUiOiJmb28udjAuMi4wIn0sInNwZWMiOnsiY3VzdG9tcmVzb3VyY2VkZWZpbml0aW9ucyI6eyJvd25lZCI6W3siZ3JvdXAiOiJ0ZXN0LmZvbyIsImtpbmQiOiJGb28iLCJuYW1lIjoiZm9vcy50ZXN0LmZvbyIsInZlcnNpb24iOiJ2MSJ9XX0sInJlbGF0ZWRJbWFnZXMiOlt7ImltYWdlIjoidGVzdC5yZWdpc3RyeS9mb28tb3BlcmF0b3IvZm9vOnYwLjIuMCIsIm5hbWUiOiJvcGVyYXRvciJ9XSwicmVwbGFjZXMiOiJmb28udjAuMS4wIiwic2tpcHMiOlsiZm9vLnYwLjEuMSIsImZvby52MC4xLjIiXSwidmVyc2lvbiI6IjAuMi4wIn19
+- type: olm.channel
+  value:
+    name: beta
+    replaces: foo.v0.1.0
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.2.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.1.0
+- type: olm.skipRange
+  value: <0.2.0
+- type: olm.skips
+  value: foo.v0.1.1
+- type: olm.skips
+  value: foo.v0.1.2
+relatedImages:
+- image: REGISTRY_ONLY/foo-operator/foo:v0.2.0
+  name: operator
+schema: olm.bundle
+---
+image: REGISTRY_ONLY/foo-operator/foo-bundle:v0.3.0
+name: foo.v0.3.0
+package: foo
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSIsInNlcnZlZCI6dHJ1ZSwic3RvcmFnZSI6ZmFsc2V9LHsibmFtZSI6InYyIiwic2VydmVkIjp0cnVlLCJzdG9yYWdlIjp0cnVlfV19fQ==
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvby52MC4zLjAifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuZm9vIiwia2luZCI6IkZvbyIsIm5hbWUiOiJmb29zLnRlc3QuZm9vIiwidmVyc2lvbiI6InYxIn0seyJncm91cCI6InRlc3QuZm9vIiwia2luZCI6IkZvbyIsIm5hbWUiOiJmb29zLnRlc3QuZm9vIiwidmVyc2lvbiI6InYyIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Zvby1vcGVyYXRvci9mb286djAuMy4wIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJyZXBsYWNlcyI6ImZvby52MC4yLjAiLCJ2ZXJzaW9uIjoiMC4zLjAifX0=
+- type: olm.channel
+  value:
+    name: beta
+    replaces: foo.v0.2.0
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v2
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.3.0
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.2.0
+relatedImages:
+- image: REGISTRY_ONLY/foo-operator/foo:v0.3.0
+  name: operator
+schema: olm.bundle
+---
+image: REGISTRY_ONLY/foo-operator/foo-bundle:v0.3.1
+name: foo.v0.3.1
+package: foo
+properties:
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoiYXBpZXh0ZW5zaW9ucy5rOHMuaW8vdjEiLCJraW5kIjoiQ3VzdG9tUmVzb3VyY2VEZWZpbml0aW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvb3MudGVzdC5mb28ifSwic3BlYyI6eyJncm91cCI6InRlc3QuZm9vIiwibmFtZXMiOnsia2luZCI6IkZvbyIsInBsdXJhbCI6ImZvb3MifSwidmVyc2lvbnMiOlt7Im5hbWUiOiJ2MSIsInNlcnZlZCI6dHJ1ZSwic3RvcmFnZSI6ZmFsc2V9LHsibmFtZSI6InYyIiwic2VydmVkIjp0cnVlLCJzdG9yYWdlIjp0cnVlfV19fQ==
+- type: olm.bundle.object
+  value:
+    data: eyJhcGlWZXJzaW9uIjoib3BlcmF0b3JzLmNvcmVvcy5jb20vdjFhbHBoYTEiLCJraW5kIjoiQ2x1c3RlclNlcnZpY2VWZXJzaW9uIiwibWV0YWRhdGEiOnsibmFtZSI6ImZvby52MC4zLjEifSwic3BlYyI6eyJjdXN0b21yZXNvdXJjZWRlZmluaXRpb25zIjp7Im93bmVkIjpbeyJncm91cCI6InRlc3QuZm9vIiwia2luZCI6IkZvbyIsIm5hbWUiOiJmb29zLnRlc3QuZm9vIiwidmVyc2lvbiI6InYxIn0seyJncm91cCI6InRlc3QuZm9vIiwia2luZCI6IkZvbyIsIm5hbWUiOiJmb29zLnRlc3QuZm9vIiwidmVyc2lvbiI6InYyIn1dfSwicmVsYXRlZEltYWdlcyI6W3siaW1hZ2UiOiJ0ZXN0LnJlZ2lzdHJ5L2Zvby1vcGVyYXRvci9mb286djAuMy4xIiwibmFtZSI6Im9wZXJhdG9yIn1dLCJyZXBsYWNlcyI6ImZvby52MC4yLjAiLCJza2lwcyI6WyJmb28udjAuMy4wIl0sInZlcnNpb24iOiIwLjMuMSJ9fQ==
+- type: olm.channel
+  value:
+    name: beta
+    replaces: foo.v0.2.0
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v1
+- type: olm.gvk
+  value:
+    group: test.foo
+    kind: Foo
+    version: v2
+- type: olm.gvk.required
+  value:
+    group: test.bar
+    kind: Bar
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: foo
+    version: 0.3.1
+- type: olm.package.required
+  value:
+    packageName: bar
+    versionRange: <0.2.0
+- type: olm.skips
+  value: foo.v0.3.0
+relatedImages:
+- image: REGISTRY_ONLY/foo-operator/foo:v0.3.1
+  name: operator
+schema: olm.bundle

--- a/test/start-docker-registry.sh
+++ b/test/start-docker-registry.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo -e "\nStarting containerized docker registry"
+
+docker run -d -p 5000:5000 --restart always --name registry registry:2

--- a/test/stop-docker-registry.sh
+++ b/test/stop-docker-registry.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+echo -e "\nCleaning up docker registry"
+
+docker stop registry || true
+docker rm registry || true

--- a/test/test-operator.sh
+++ b/test/test-operator.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eu
+
+CMD="${1:?cmd bin path is required}"
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DATA_TMP=$(mktemp -d "${DIR}/operator-test.XXXXX")
+OUTPUT_DIR="${DATA_TMP}/output"
+
+trap "rm -rf $DATA_TMP; ${DIR}/stop-docker-registry.sh" EXIT
+
+"${DIR}/start-docker-registry.sh"
+"${DIR}/operator/setup-testdata.sh" "$DATA_TMP" "$OUTPUT_DIR"
+"$CMD" create full --dir "$OUTPUT_DIR" --log-level debug --skip-tls


### PR DESCRIPTION
Implemented `create full` for operator catalogs, and added simple e2e tests.

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>