### PR TITLE
fix(mirror): use quay.io images in unit tests to avoid docker limits

### DIFF
--- a/pkg/bundle/additional_test.go
+++ b/pkg/bundle/additional_test.go
@@ -6,16 +6,18 @@ import (
 	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
 )
 
+// TODO: use some oc lib to mock image mirroring, or mirror from files.
+
 func Test_GetAdditional(t *testing.T) {
 
 	mirror := v1alpha1.PastMirror{}
 	cfg := v1alpha1.ImageSetConfiguration{}
 	cfg.Mirror = v1alpha1.Mirror{
 		BlockedImages: []v1alpha1.BlockedImages{
-			{Image: v1alpha1.Image{Name: "alpine"}},
+			{Image: v1alpha1.Image{Name: "quay.io/estroz/pull-tester-blocked"}},
 		},
 		AdditionalImages: []v1alpha1.AdditionalImages{
-			{Image: v1alpha1.Image{Name: "docker.io/library/busybox:latest"}},
+			{Image: v1alpha1.Image{Name: "quay.io/estroz/pull-tester-additional:latest"}},
 		},
 	}
 


### PR DESCRIPTION
This is just a holdover until a better solution is found.

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>