### PR TITLE
feat(mirror): handling pull secrets through imageset config

### DIFF
--- a/data/imageset-config.yaml
+++ b/data/imageset-config.yaml
@@ -9,8 +9,10 @@ mirror:
           - '4.6.36'
           - '4.6.13'
     graph: true
+    pullSecret: '{"auths":{"cloud.openshift.com":..."}}}'
   operators:
     - catalog: redhat-operators:v4.7
+      pullSecret: '{"auths":{"cloud.openshift.com":..."}}}'
     - catalog: certified-operators:v4.7
       packages:
         - name: couchbase-operator
@@ -28,7 +30,7 @@ mirror:
     - name: nginx
   additionalimages:
     - name: registry.redhat.io/ubi8/ubi:latest
+      pullSecret: '{"auths":{"cloud.openshift.com":..."}}}'
   blockedimages:
     - name: alpine
     - name: redis
-pullsecret: '{"auths":{"cloud.openshift.com":..."}}}'

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,13 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bshuster-repo/logrus-logstash-hook v1.0.2 // indirect
 	github.com/containerd/containerd v1.4.8
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/google/uuid v1.2.0
 	github.com/joelanford/ignore v0.0.0-20210610194209-63d4919d8fb2
 	github.com/mattn/go-sqlite3 v1.14.8 // indirect
 	github.com/mholt/archiver/v3 v3.5.0
+	github.com/openshift/installer v0.16.1
 	github.com/openshift/library-go v0.0.0-20210521084623-7392ea9b02ca
 	github.com/openshift/oc v0.0.0-alpha.0.0.20210721184532-4df50be4d929
 	github.com/operator-framework/operator-registry v0.0.0-00010101000000-000000000000
@@ -23,6 +25,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	k8s.io/apimachinery v0.21.1
 	k8s.io/cli-runtime v0.21.1
+	k8s.io/client-go v0.21.1
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.8.0
 	rsc.io/letsencrypt v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -771,6 +771,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210423112049-9415d7ebd33e/go.mo
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 h1:ZHRIMCFIJN1p9LsJt4HQ+akDrys4PrYnXzOWI5LK03I=
 github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142/go.mod h1:fjS8r9mqDVsPb5td3NehsNOAWa4uiFkYEfVZioQ2gH0=
 github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b/go.mod h1:tNrEB5k8SI+g5kOlsCmL2ELASfpqEofI0+FLBgBdN08=
+github.com/openshift/installer v0.16.1 h1:PmjALN9x1NVNVi3SCqfz0ZwVCgOkQLQWo2nHYXREq/A=
+github.com/openshift/installer v0.16.1/go.mod h1:VWGgpJgF8DGCKQjbccnigglhZnHtRLCZ6cxqkXN4Ck0=
 github.com/openshift/kubernetes-apimachinery v0.0.0-20210521074607-b6b98f7a1855 h1:khHF9qoWk0DmeMYuSA5xl6x2QBRz2fAbBmWy7/eNh1g=
 github.com/openshift/kubernetes-apimachinery v0.0.0-20210521074607-b6b98f7a1855/go.mod h1:jbreFvJo3ov9rj7eWT7+sYiRx+qZuCYXwWT1bcDswPY=
 github.com/openshift/kubernetes-cli-runtime v0.0.0-20210521074950-112a61d2624f h1:E947H/9FCcL1iIJzagRXxQTistNiXcYotY/0K17EzL8=

--- a/pkg/bundle/create/create.go
+++ b/pkg/bundle/create/create.go
@@ -69,8 +69,18 @@ func CreateFull(configPath, rootDir, outputDir string, dryRun, insecure bool) er
 		return err
 	}
 
+	logrus.Info("Verifying pull secrets")
+	// Validating pull secrets
+	if err := config.ValidateSecret(cfg); err != nil {
+		return err
+	}
+
 	if len(cfg.Mirror.OCP.Channels) != 0 {
-		if err = bundle.GetReleasesInitial(cfg, sourceDir); err != nil {
+		opts := bundle.NewReleaseOptions()
+		opts.RootDestDir = sourceDir
+		opts.DryRun = dryRun
+		opts.SkipTLS = insecure
+		if err = opts.GetReleasesInitial(cfg); err != nil {
 			return err
 		}
 	}
@@ -179,9 +189,18 @@ func CreateDiff(configPath, rootDir, outputDir string, dryRun, insecure bool) er
 		return err
 	}
 
-	if len(cfg.Mirror.OCP.Channels) != 0 {
+	logrus.Info("Verifying pull secrets")
+	// Validating pull secrets
+	if err := config.ValidateSecret(cfg); err != nil {
+		return err
+	}
 
-		if err = bundle.GetReleasesDiff(lastRun, cfg, sourceDir); err != nil {
+	if len(cfg.Mirror.OCP.Channels) != 0 {
+		opts := bundle.NewReleaseOptions()
+		opts.RootDestDir = sourceDir
+		opts.DryRun = dryRun
+		opts.SkipTLS = insecure
+		if err = opts.GetReleasesDiff(lastRun, cfg); err != nil {
 			return err
 		}
 	}
@@ -201,7 +220,6 @@ func CreateDiff(configPath, rootDir, outputDir string, dryRun, insecure bool) er
 	}
 
 	if len(cfg.Mirror.AdditionalImages) != 0 {
-
 		opts := bundle.NewAdditionalOptions()
 		opts.DestDir = rootDir
 		opts.DryRun = dryRun

--- a/pkg/bundle/files_test.go
+++ b/pkg/bundle/files_test.go
@@ -1,0 +1,64 @@
+package bundle
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
+)
+
+func Test_ReconcilingFiles(t *testing.T) {
+	type fields struct {
+		files []v1alpha1.File
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []string
+	}{
+		{
+			name: "testing want to block",
+			fields: fields{
+				files: []v1alpha1.File{
+					{Name: "test1"},
+				},
+			},
+			want: []string{"test2"},
+		},
+	}
+	for _, tt := range tests {
+		meta := v1alpha1.Metadata{
+			MetadataSpec: v1alpha1.MetadataSpec{
+				PastFiles: tt.fields.files,
+			},
+		}
+
+		tmpdir := t.TempDir()
+
+		if err := os.Chdir(tmpdir); err != nil {
+			t.Fatal(err)
+		}
+
+		d1 := []byte("hello\ngo\n")
+		if err := ioutil.WriteFile("test2", d1, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := ioutil.WriteFile("test1", d1, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		actual, err := ReconcileFiles(&meta, ".")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(actual, tt.want) {
+			t.Errorf("Test %s: Expected '%v', got '%v'", tt.name, tt.want, actual)
+		}
+
+	}
+}

--- a/pkg/bundle/files_test.go
+++ b/pkg/bundle/files_test.go
@@ -37,9 +37,17 @@ func Test_ReconcilingFiles(t *testing.T) {
 
 		tmpdir := t.TempDir()
 
+		cwd, err := os.Getwd()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		if err := os.Chdir(tmpdir); err != nil {
 			t.Fatal(err)
 		}
+
+		defer os.Chdir(cwd)
 
 		d1 := []byte("hello\ngo\n")
 		if err := ioutil.WriteFile("test2", d1, 0644); err != nil {

--- a/pkg/bundle/release.go
+++ b/pkg/bundle/release.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/RedHatGov/bundle/pkg/config"
 	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
 )
 
@@ -25,6 +26,20 @@ import (
 // import(
 //   "github.com/openshift/cluster-version-operator/pkg/cincinnati"
 // )
+
+// ReleaseOptions configures either a Full or Diff mirror operation
+// on a particular release image.
+type ReleaseOptions struct {
+	RootDestDir string
+	DryRun      bool
+	Cleanup     bool
+	SkipTLS     bool
+}
+
+// NewReleaseOptions defaults ReleaseOptions.
+func NewReleaseOptions() *ReleaseOptions {
+	return &ReleaseOptions{}
+}
 
 // Define interface and var for http client to support testing
 type HTTPClient interface {
@@ -197,7 +212,7 @@ func (c Client) GetChannelLatest(ctx context.Context, uri *url.URL, arch string,
 	return new, err
 }
 
-func downloadMirror(i string, rootDir string) error {
+func downloadMirror(secret []byte, rootDir, from string, skipTlS, dryRun bool) error {
 	stream := genericclioptions.IOStreams{
 		In:     os.Stdin,
 		Out:    os.Stdout,
@@ -205,8 +220,24 @@ func downloadMirror(i string, rootDir string) error {
 	}
 	opts := release.NewMirrorOptions(stream)
 
-	opts.From = i
+	opts.From = from
 	opts.ToDir = rootDir
+
+	// FIXME(jpower): need to have the user set skipVerification value
+	// If the pullSecret is not empty create a cached context
+	// else let `oc mirror` use the default docker config location
+	if len(secret) != 0 {
+		ctx, err := config.CreateContext(secret, false, skipTlS)
+
+		if err != nil {
+			return nil
+		}
+
+		opts.SecurityOptions.CachedContext = ctx
+	}
+
+	opts.SecurityOptions.Insecure = skipTlS
+	opts.DryRun = dryRun
 
 	if err := opts.Run(); err != nil {
 		return err
@@ -215,7 +246,9 @@ func downloadMirror(i string, rootDir string) error {
 
 }
 
-func GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration, rootDir string) error {
+func (o *ReleaseOptions) GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration) error {
+
+	pullSecret := cfg.Mirror.OCP.PullSecret
 
 	// For each channel in the config file
 	for _, ch := range cfg.Mirror.OCP.Channels {
@@ -229,7 +262,7 @@ func GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration, rootDir string) erro
 			}
 			logrus.Infof("Image to download: %v", latest.Image)
 			// Download the release
-			err = downloadMirror(latest.Image, rootDir)
+			err = downloadMirror([]byte(pullSecret), o.RootDestDir, latest.Image, o.SkipTLS, o.DryRun)
 			if err != nil {
 				logrus.Errorln(err)
 			}
@@ -253,7 +286,7 @@ func GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration, rootDir string) erro
 			}
 
 			logrus.Infof("requested: %v", requested.Version)
-			err = downloadMirror(requested.Image, rootDir)
+			err = downloadMirror([]byte(pullSecret), o.RootDestDir, requested.Image, o.SkipTLS, o.DryRun)
 			if err != nil {
 				return err
 			}
@@ -287,9 +320,11 @@ func GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration, rootDir string) erro
 	return nil
 }
 
-func GetReleasesDiff(_ v1alpha1.PastMirror, c v1alpha1.ImageSetConfiguration, rootDir string) error {
+func (o *ReleaseOptions) GetReleasesDiff(_ v1alpha1.PastMirror, cfg v1alpha1.ImageSetConfiguration) error {
 
-	for _, ch := range c.Mirror.OCP.Channels {
+	pullSecret := cfg.Mirror.OCP.PullSecret
+
+	for _, ch := range cfg.Mirror.OCP.Channels {
 		// Check for specific version declarations for each specific version
 		for _, v := range ch.Versions {
 
@@ -307,7 +342,7 @@ func GetReleasesDiff(_ v1alpha1.PastMirror, c v1alpha1.ImageSetConfiguration, ro
 			}
 
 			logrus.Infof("requested: %v", requested.Version)
-			err = downloadMirror(requested.Image, rootDir)
+			err = downloadMirror([]byte(pullSecret), o.RootDestDir, requested.Image, o.SkipTLS, o.DryRun)
 			if err != nil {
 				return err
 			}

--- a/pkg/config/credentials.go
+++ b/pkg/config/credentials.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/distribution/registry/client/transport"
+	"github.com/openshift/library-go/pkg/image/registryclient"
+	"github.com/openshift/oc/pkg/helpers/image/credentialprovider"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+)
+
+// New creates a new credential store for the provided secret content
+func New(secret []byte) (auth.CredentialStore, error) {
+
+	cfg, err := readDockerConfigJSONFileFromBytes(secret)
+	if err != nil {
+		return nil, err
+	}
+	keyring := &credentialprovider.BasicDockerKeyring{}
+	keyring.Add(cfg)
+	return &keyringCredentialStore{
+		DockerKeyring:     keyring,
+		RefreshTokenStore: registryclient.NewRefreshTokenStore(),
+	}, nil
+}
+
+// CreateContext a new context for the registryClient of `oc mirror`
+func CreateContext(secret []byte, skipVerification bool, skipTLS bool) (*registryclient.Context, error) {
+	rt, err := rest.TransportFor(&rest.Config{})
+	if err != nil {
+		return nil, err
+	}
+	insecureRT, err := rest.TransportFor(&rest.Config{TLSClientConfig: rest.TLSClientConfig{Insecure: skipTLS}})
+	if err != nil {
+		return nil, err
+	}
+	creds, err := New(secret)
+
+	if err != nil {
+		return nil, err
+	}
+	context := registryclient.NewContext(rt, insecureRT).WithCredentials(creds).WithRequestModifiers(transport.NewHeaderRequestModifier(
+		http.Header{
+			http.CanonicalHeaderKey("User-Agent"): []string{rest.DefaultKubernetesUserAgent()},
+		},
+	))
+	context.DisableDigestVerification = skipVerification
+	return context, nil
+}
+
+// Copied below from https://github.com/openshift/oc/blob/d922a789a1add3146f69bacadaed8c3fb719f333/pkg/cli/image/manifest/dockercredentials/credentials.go#L49
+// May be temporary
+
+type keyringCredentialStore struct {
+	credentialprovider.DockerKeyring
+	registryclient.RefreshTokenStore
+}
+
+func (s *keyringCredentialStore) Basic(url *url.URL) (string, string) {
+	return BasicFromKeyring(s.DockerKeyring, url)
+}
+
+// BasicFromKeyring finds Basic authorization credentials from a Docker keyring for the given URL as username and
+// password. It returns empty strings if no such URL matches.
+func BasicFromKeyring(keyring credentialprovider.DockerKeyring, target *url.URL) (string, string) {
+	// TODO: compare this logic to Docker authConfig in v2 configuration
+	var value string
+	if len(target.Scheme) == 0 || target.Scheme == "https" {
+		value = target.Host + target.Path
+	} else {
+		// always require an explicit port to look up HTTP credentials
+		if !strings.Contains(target.Host, ":") {
+			value = target.Host + ":80" + target.Path
+		} else {
+			value = target.Host + target.Path
+		}
+	}
+
+	// Lookup(...) expects an image (not a URL path).
+	// The keyring strips /v1/ and /v2/ version prefixes,
+	// so we should also when selecting a valid auth for a URL.
+	pathWithSlash := target.Path + "/"
+	if strings.HasPrefix(pathWithSlash, "/v1/") || strings.HasPrefix(pathWithSlash, "/v2/") {
+		value = target.Host + target.Path[3:]
+	}
+
+	configs, found := keyring.Lookup(value)
+
+	if !found || len(configs) == 0 {
+		// do a special case check for docker.io to match historical lookups when we respond to a challenge
+		if value == "auth.docker.io/token" {
+			klog.V(5).Infof("Being asked for %s (%s), trying %s for legacy behavior", target, value, "index.docker.io/v1")
+			return BasicFromKeyring(keyring, &url.URL{Host: "index.docker.io", Path: "/v1"})
+		}
+		// docker 1.9 saves 'docker.io' in config in f23, see https://bugzilla.redhat.com/show_bug.cgi?id=1309739
+		if value == "index.docker.io" {
+			klog.V(5).Infof("Being asked for %s (%s), trying %s for legacy behavior", target, value, "docker.io")
+			return BasicFromKeyring(keyring, &url.URL{Host: "docker.io"})
+		}
+
+		// try removing the canonical ports for the given requests
+		if (strings.HasSuffix(target.Host, ":443") && target.Scheme == "https") ||
+			(strings.HasSuffix(target.Host, ":80") && target.Scheme == "http") {
+			host := strings.SplitN(target.Host, ":", 2)[0]
+			klog.V(5).Infof("Being asked for %s (%s), trying %s without port", target, value, host)
+
+			return BasicFromKeyring(keyring, &url.URL{Scheme: target.Scheme, Host: host, Path: target.Path})
+		}
+
+		klog.V(5).Infof("Unable to find a secret to match %s (%s)", target, value)
+		return "", ""
+	}
+	klog.V(5).Infof("Found secret to match %s (%s): %s", target, value, configs[0].ServerAddress)
+	return configs[0].Username, configs[0].Password
+}
+
+func readDockerConfigJSONFileFromBytes(contents []byte) (cfg credentialprovider.DockerConfig, err error) {
+	var cfgJSON credentialprovider.DockerConfigJSON
+	if err = json.Unmarshal(contents, &cfgJSON); err != nil {
+		return nil, errors.New("error occurred while trying to unmarshal json")
+	}
+	cfg = cfgJSON.Auths
+	return
+}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -8,6 +8,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
+	"github.com/openshift/installer/pkg/validate"
+	"github.com/sirupsen/logrus"
 )
 
 // TODO(estroz): create interface scheme such that configuration and metadata
@@ -39,4 +41,39 @@ func getTypeMeta(data []byte) (typeMeta metav1.TypeMeta, err error) {
 		return typeMeta, fmt.Errorf("get type meta: %v", err)
 	}
 	return typeMeta, nil
+}
+
+func ValidateSecret(cfg v1alpha1.ImageSetConfiguration) error {
+
+	mirror := cfg.Mirror
+
+	// Check OCP for validate pull secret
+	if len(mirror.OCP.PullSecret) != 0 {
+		logrus.Debug("Validating OCP secret")
+		if err := validate.ImagePullSecret(mirror.OCP.PullSecret); err != nil {
+			return fmt.Errorf("error validating OCP pullSecret: %v", err)
+		}
+	}
+
+	// Check Operator for validate pull secret
+	logrus.Debug("Validating operator secrets")
+	for _, op := range mirror.Operators {
+		if len(op.PullSecret) != 0 {
+			if err := validate.ImagePullSecret(op.PullSecret); err != nil {
+				return fmt.Errorf("error validating secret for operator catalog %s: %v", op.Catalog, err)
+			}
+		}
+	}
+
+	// Check Additional Images for validate pull secret
+	logrus.Debug("Validating additional image secrets")
+	for _, img := range mirror.AdditionalImages {
+		if len(img.PullSecret) != 0 {
+			if err := validate.ImagePullSecret(img.PullSecret); err != nil {
+				return fmt.Errorf("error validating secret for image %s: %v", img, err)
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Features:
- Processes pullSecret for OCP, each catalog, and each user defined image
- If the pullSecret is not specified `oc mirror` will default for the docker config default place