### PR TITLE
fix: changed path to remove extra src and added targetfn to release dest

### DIFF
--- a/pkg/bundle/additional.go
+++ b/pkg/bundle/additional.go
@@ -97,5 +97,5 @@ func (o *AdditionalOptions) GetAdditional(_ v1alpha1.PastMirror, cfg v1alpha1.Im
 		return nil, err
 	}
 
-	return image.AssociateImageLayers(o.DestDir, assocMappings, images)
+	return image.AssociateImageLayers(opts.FileDir, assocMappings, images)
 }

--- a/pkg/bundle/release.go
+++ b/pkg/bundle/release.go
@@ -243,11 +243,13 @@ func downloadMirror(secret []byte, toDir, from string, skipTlS, dryRun bool) (as
 		return assocs, err
 	}
 
+	dst := opts.TargetFn("")
+
 	// There is currently no way to retrieve mappings created by mirror options,
 	// so we must assume the release image is mirrored directly to the specified
 	// dir at the image name path.
 	mapping := map[string]string{
-		from: fmt.Sprintf("file://%s", from),
+		from: dst.Exact(),
 	}
 	return image.AssociateImageLayers(toDir, mapping, []string{from})
 }

--- a/pkg/image/association.go
+++ b/pkg/image/association.go
@@ -15,8 +15,6 @@ import (
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-
-	"github.com/RedHatGov/bundle/pkg/config"
 )
 
 // Associations is a set of image Associations.
@@ -117,7 +115,7 @@ func AssociateImageLayers(rootDir string, imgMappings map[string]string, images 
 			return nil, fmt.Errorf("image %q has no mirror mapping", image)
 		}
 		dirRef = strings.TrimPrefix(dirRef, "file://")
-		dirRef = filepath.Join(rootDir, config.SourceDir, "v2", dirRef)
+		dirRef = filepath.Join(rootDir, "v2", dirRef)
 
 		tagIdx := strings.LastIndex(dirRef, ":")
 		if tagIdx == -1 {

--- a/pkg/operator/mirror.go
+++ b/pkg/operator/mirror.go
@@ -420,7 +420,8 @@ func (o *MirrorOptions) associateDeclarativeConfigImageLayers(mappingDir string,
 			return err
 		}
 
-		assocs, err := image.AssociateImageLayers(o.RootDestDir, imgMappings, images)
+		srcDir := filepath.Join(o.RootDestDir, config.SourceDir)
+		assocs, err := image.AssociateImageLayers(srcDir, imgMappings, images)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR adds a fix required to successfully add image associations for releases.
- Remove extra "src" from mapping destination path
- Used `oc` TargetFn to get the manifest location for the release image