### PR TITLE
fix: create a custom error for image mapping

### DIFF
--- a/pkg/image/association.go
+++ b/pkg/image/association.go
@@ -17,6 +17,14 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
+type MirrorError struct {
+	image string
+}
+
+func (e *MirrorError) Error() string {
+	return fmt.Sprintf("image %q has no mirror mapping", e.image)
+}
+
 // Associations is a set of image Associations.
 type Associations map[string]Association
 
@@ -112,7 +120,7 @@ func AssociateImageLayers(rootDir string, imgMappings map[string]string, images 
 	for _, image := range images {
 		dirRef, hasMapping := imgMappings[image]
 		if !hasMapping {
-			return nil, fmt.Errorf("image %q has no mirror mapping", image)
+			return nil, &MirrorError{image}
 		}
 		dirRef = strings.TrimPrefix(dirRef, "file://")
 		dirRef = filepath.Join(rootDir, "v2", dirRef)

--- a/pkg/operator/mirror.go
+++ b/pkg/operator/mirror.go
@@ -422,9 +422,12 @@ func (o *MirrorOptions) associateDeclarativeConfigImageLayers(mappingDir string,
 
 		srcDir := filepath.Join(o.RootDestDir, config.SourceDir)
 		assocs, err := image.AssociateImageLayers(srcDir, imgMappings, images)
-		if err != nil {
+		if merr, ok := err.(*image.MirrorError); ok {
+			logrus.Warn(merr)
+		} else {
 			return err
 		}
+
 		allAssocs.Merge(assocs)
 		return nil
 	}); err != nil {


### PR DESCRIPTION
- Creates a custom error for "image missing mapping" because operator do not always have mapping information. This logs a warning instead.