### PR TITLE
feat(create): layer and manifest tracking 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Test artifacts.
 coverage.out
-**/bundle*.tar.gz
+**/bundle*.tar
 sha256sum.txt
 /test/operator-test.*
 **/publish.tmp.*

--- a/cmd/oc-bundle/create.go
+++ b/cmd/oc-bundle/create.go
@@ -50,7 +50,9 @@ func newCreateFullCmd(o *createOpts) *cobra.Command {
 			defer cleanup()
 			logrus.Infoln("Create full called")
 
-			err := create.CreateFull(cmd.Context(), o.configPath, o.dir, o.outputDir, o.dryRun, o.skipTLS, o.skipCleanup)
+			creator := create.NewCreator(o.configPath, o.dir, o.outputDir, o.dryRun, o.skipTLS, o.skipCleanup)
+
+			err := creator.CreateFull(cmd.Context())
 			if err != nil {
 				logrus.Fatal(err)
 			}
@@ -69,7 +71,9 @@ func newCreateDiffCmd(o *createOpts) *cobra.Command {
 			defer cleanup()
 			logrus.Infoln("Create Diff called")
 
-			err := create.CreateDiff(cmd.Context(), o.configPath, o.dir, o.outputDir, o.dryRun, o.skipTLS, o.skipCleanup)
+			creator := create.NewCreator(o.configPath, o.dir, o.outputDir, o.dryRun, o.skipTLS, o.skipCleanup)
+
+			err := creator.CreateDiff(cmd.Context())
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -117,6 +117,8 @@ func CreateSplitArchive(a Archiver, maxSplitSize int64, destDir, sourceDir, pref
 			return fmt.Errorf("%s: writing: %s", fpath, err)
 		}
 
+		logrus.Debugf("File %s added to archive %s", fpath, splitPath)
+
 		splitSize += info.Size()
 
 		return nil

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -5,9 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/RedHatGov/bundle/pkg/config"
 	"github.com/mholt/archiver/v3"
 	"github.com/sirupsen/logrus"
 )
@@ -24,41 +22,29 @@ type Archiver interface {
 	Read() (archiver.File, error)
 }
 
-// NewArchiver create a new archiver for tar archive manipultation
+// NewArchiver creates a new archiver for tar archive manipultation
 func NewArchiver() Archiver {
-	// Create tar specifically with overrite on false
-	return &archiver.TarGz{
-
-		Tar: &archiver.Tar{
-			OverwriteExisting:      true,
-			MkdirAll:               true,
-			ImplicitTopLevelFolder: false,
-			StripComponents:        0,
-			ContinueOnError:        false,
-		},
+	return &archiver.Tar{
+		OverwriteExisting:      false,
+		MkdirAll:               true,
+		ImplicitTopLevelFolder: false,
+		StripComponents:        0,
+		ContinueOnError:        false,
 	}
 }
 
 // CreateSplitAchrive will create multiple tar archives from source directory
-func CreateSplitArchive(a Archiver, maxSplitSize int64, destDir, sourceDir, prefix string, newFiles []string) error {
-
-	logrus.Debugf("Found new files %v", newFiles)
+func CreateSplitArchive(a Archiver, maxSplitSize int64, destDir, sourceDir, prefix string) error {
 
 	// Declare split variables
 	splitNum := 0
 	splitSize := int64(0)
 	splitPath := fmt.Sprintf("%s/%s_%06d.%s", destDir, prefix, splitNum, a.String())
 
-	splitFile, err := os.Create(splitPath)
+	splitFile, err := createArchive(a, splitPath)
 
 	if err != nil {
-		return fmt.Errorf("creating %s: %v", splitPath, err)
-	}
-
-	// Create a new tar archive for writing
-	logrus.Infof("Creating archive %s", splitPath)
-	if a.Create(splitFile); err != nil {
-		return fmt.Errorf("creating archive %s: %v", splitPath, err)
+		return fmt.Errorf("error creating archive %s: %v", splitPath, err)
 	}
 
 	sourceInfo, err := os.Stat(sourceDir)
@@ -66,13 +52,6 @@ func CreateSplitArchive(a Archiver, maxSplitSize int64, destDir, sourceDir, pref
 	if err != nil {
 		return fmt.Errorf("%s: stat: %v", sourceDir, err)
 	}
-
-	fileSetToArchive := make(map[string]struct{}, len(newFiles))
-	for _, fpath := range newFiles {
-		fileSetToArchive[fpath] = struct{}{}
-	}
-	// Ignore the current dir.
-	fileSetToArchive["."] = struct{}{}
 
 	walkErr := filepath.Walk(sourceDir, func(fpath string, info os.FileInfo, err error) error {
 
@@ -83,18 +62,12 @@ func CreateSplitArchive(a Archiver, maxSplitSize int64, destDir, sourceDir, pref
 			return fmt.Errorf("no file info")
 		}
 
-		// Make sure the metadata file is always packed
-		if strings.Contains(fpath, config.MetadataFile) {
-			logrus.Debugf("Packing metadata file %s", fpath)
-			fileSetToArchive[fpath] = struct{}{}
+		// skip V2 directory because we have already copied over
+		// what we needed during reconcilination
+		if info.IsDir() && info.Name() == "v2" && filepath.Dir(fpath) != "manifests" {
+			return filepath.SkipDir
 		}
 
-		if _, archive := fileSetToArchive[fpath]; !archive {
-			logrus.Debugf("File %s should not be archived, skipping...", fpath)
-			return nil
-		}
-
-		// build the name to be used within the archive
 		nameInArchive, err := archiver.NameInArchive(sourceInfo, sourceDir, fpath)
 		if err != nil {
 			return fmt.Errorf("creating %s: %v", nameInArchive, err)
@@ -124,24 +97,19 @@ func CreateSplitArchive(a Archiver, maxSplitSize int64, destDir, sourceDir, pref
 			a.Close()
 			splitFile.Close()
 
+			logrus.Info(splitSize)
+
 			// Increment split number and reset splitSize
 			splitNum += 1
 			splitSize = int64(0)
 			splitPath = fmt.Sprintf("%s/%s_%06d.%s", destDir, prefix, splitNum, a.String())
 
 			// Create a new tar archive for writing
-			logrus.Infof("Creating archive %s", splitPath)
-
-			splitFile, err = os.Create(splitPath)
+			splitFile, err = createArchive(a, splitPath)
 
 			if err != nil {
-				return fmt.Errorf("creating %s: %v", splitPath, err)
+				return fmt.Errorf("error creating archive %s: %v", splitPath, err)
 			}
-
-			if err := a.Create(splitFile); err != nil {
-				return fmt.Errorf("creating archive %s: %v", splitPath, err)
-			}
-
 		}
 
 		// Write file to current archive file
@@ -166,71 +134,20 @@ func CreateSplitArchive(a Archiver, maxSplitSize int64, destDir, sourceDir, pref
 	return walkErr
 }
 
-// CombineArchives take a list of archives and combines them into one file
-func CombineArchives(in Archiver, out Archiver, destDir, name string, paths ...string) error {
+// createArchive is a helper function that prepares a new split archive
+func createArchive(a Archiver, splitPath string) (splitFile *os.File, err error) {
 
-	outPath := filepath.Join(destDir, name)
-
-	// Open new archive
-	outFile, err := os.Create(outPath)
-
+	// create a new target file
+	splitFile, err = os.Create(splitPath)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("creating %s: %v", splitPath, err)
 	}
 
 	// Create a new tar archive for writing
-	if out.Create(outFile); err != nil {
-		return err
+	logrus.Infof("Creating archive %s", splitPath)
+	if a.Create(splitFile); err != nil {
+		return nil, fmt.Errorf("creating archive %s: %v", splitPath, err)
 	}
 
-	for _, p := range paths {
-
-		// Read in the source tar archive
-		inFile, err := os.Open(p)
-
-		if err != nil {
-			return fmt.Errorf("could not open current file %s: %v", p, err)
-		}
-
-		// Open the tar archive for reading
-		if err := in.Open(inFile, 0); err != nil {
-			return fmt.Errorf("error opening archive %s: %v", p, err)
-		}
-
-		// Loop through the files in the source tar
-		readErr := func() error {
-			for {
-				// Read current byte and check if we are at the end of the the file
-				f, err := in.Read()
-				header := f.Header
-				switch {
-				case err == io.EOF:
-					return nil
-				case err != nil:
-					return err
-				case header == nil:
-					continue
-				}
-
-				// Write file to current archive
-				if err := out.Write(f); err != nil {
-					return err
-				}
-			}
-		}()
-
-		if readErr != nil {
-			return readErr
-		}
-
-		if err := in.Close(); err != nil {
-			return err
-		}
-	}
-
-	if err := out.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return splitFile, nil
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -2,11 +2,20 @@ package archive
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/RedHatGov/bundle/pkg/bundle"
+	"github.com/RedHatGov/bundle/pkg/config"
+	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
 )
+
+/* FIXME(jpower): known issue with many small files
+the tar size will end up larger than specified by the
+ user because of the tar header being written*/
 
 func Test_SplitArchive(t *testing.T) {
 
@@ -14,34 +23,54 @@ func Test_SplitArchive(t *testing.T) {
 
 	defer os.RemoveAll(testdir)
 
+	a := NewArchiver()
+
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	a := NewArchiver()
 
 	tests := []struct {
 		name         string
 		source       string
 		maxSplitSize int64
-		files        []string
+		blobs        []v1alpha1.Blob
+		manifests    []v1alpha1.Manifest
 		want         string
 	}{
 		{
-			name:         "testing gz format",
-			source:       "../../test",
-			files:        []string{"../../test"},
-			maxSplitSize: 1000000,
+			name:         "testing tar format",
+			blobs:        []v1alpha1.Blob{{Name: "sha256:123456789"}},
+			manifests:    []v1alpha1.Manifest{{Name: "testmanifest"}},
+			maxSplitSize: 5 * 1024 * 1024,
 			want:         "testbundle",
 		},
 	}
 	for _, tt := range tests {
 
-		if err := CreateSplitArchive(a, tt.maxSplitSize, testdir, tt.source, tt.want, tt.files); err != nil {
+		if err := bundle.MakeCreateDirs(testdir); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Change dir before archiving to avoid issues with symlink paths
+		if err := os.Chdir(filepath.Join(testdir, config.SourceDir)); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(cwd)
+
+		if err := writeFiles(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := CreateSplitArchive(a, tt.maxSplitSize, cwd, ".", tt.want); err != nil {
 			t.Errorf("Test %s: Failed to create archives for %s: %v", tt.name, tt.want, err)
 		}
 
-		err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		err = filepath.Walk(cwd, func(path string, info os.FileInfo, err error) error {
 
 			if strings.Contains(info.Name(), tt.want) {
 
@@ -61,49 +90,15 @@ func Test_SplitArchive(t *testing.T) {
 	}
 }
 
-func Test_CombineArchive(t *testing.T) {
+// writeFiles write out testfiles to be archived
+func writeFiles() error {
+	d1 := []byte("hello\ngo\n")
 
-	in := NewArchiver()
-	out := NewArchiver()
-
-	tests := []struct {
-		name   string
-		source string
-		output string
-	}{
-		{
-			name:   "testing gz format",
-			source: "../../test/archiver/testdata/",
-			output: "testbundle-combined.tar.gz",
-		},
+	for i := 0; i < 100; i++ {
+		if err := ioutil.WriteFile(fmt.Sprintf("test%d", i), d1, 0644); err != nil {
+			return err
+		}
 	}
-	for _, tt := range tests {
 
-		var bundleList []string
-
-		err := filepath.Walk(tt.source, func(path string, info os.FileInfo, err error) error {
-
-			if strings.Contains(info.Name(), "bar-bundle") {
-
-				bundleList = append(bundleList, path)
-			}
-
-			return nil
-		})
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		if err = CombineArchives(in, out, ".", tt.output, bundleList...); err != nil {
-			t.Errorf("Test %s: Failed to combine archives for %s: %v", tt.name, tt.output, err)
-		}
-
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		os.RemoveAll(tt.output)
-
-	}
+	return nil
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -23,8 +23,6 @@ func Test_SplitArchive(t *testing.T) {
 
 	defer os.RemoveAll(testdir)
 
-	a := NewArchiver()
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,6 +45,8 @@ func Test_SplitArchive(t *testing.T) {
 	}
 	for _, tt := range tests {
 
+		packager := NewPackager(tt.manifests, tt.blobs)
+
 		if err := bundle.MakeCreateDirs(testdir); err != nil {
 			t.Fatal(err)
 		}
@@ -66,7 +66,7 @@ func Test_SplitArchive(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := CreateSplitArchive(a, tt.maxSplitSize, cwd, ".", tt.want); err != nil {
+		if err := packager.CreateSplitArchive(tt.maxSplitSize, cwd, ".", tt.want); err != nil {
 			t.Errorf("Test %s: Failed to create archives for %s: %v", tt.name, tt.want, err)
 		}
 

--- a/pkg/bundle/create/create.go
+++ b/pkg/bundle/create/create.go
@@ -59,6 +59,26 @@ func (c creator) CreateFull(ctx context.Context) error {
 		return err
 	}
 
+	if !c.skipCleanup {
+		defer func() {
+			if err := os.RemoveAll(filepath.Join(c.sourceDir, "v2")); err != nil {
+				logrus.Fatal(err)
+			}
+		}()
+	}
+
+	defer func() {
+		if err := os.RemoveAll(filepath.Join(c.sourceDir, "blobs")); err != nil {
+			logrus.Fatal(err)
+		}
+	}()
+
+	defer func() {
+		if err := os.RemoveAll(filepath.Join(c.sourceDir, "manifests")); err != nil {
+			logrus.Fatal(err)
+		}
+	}()
+
 	// TODO: make backend configurable.
 	backend, err := storage.NewLocalBackend(c.rootDir)
 	if err != nil {
@@ -178,6 +198,26 @@ func (c creator) CreateDiff(ctx context.Context) error {
 	if err := bundle.MakeCreateDirs(c.rootDir); err != nil {
 		return err
 	}
+
+	if !c.skipCleanup {
+		defer func() {
+			if err := os.RemoveAll(filepath.Join(c.sourceDir, "v2")); err != nil {
+				logrus.Fatal(err)
+			}
+		}()
+	}
+
+	defer func() {
+		if err := os.RemoveAll(filepath.Join(c.sourceDir, "blobs")); err != nil {
+			logrus.Fatal(err)
+		}
+	}()
+
+	defer func() {
+		if err := os.RemoveAll(filepath.Join(c.sourceDir, "manifests")); err != nil {
+			logrus.Fatal(err)
+		}
+	}()
 
 	// TODO: make backend configurable.
 	backend, err := storage.NewLocalBackend(c.rootDir)

--- a/pkg/bundle/files.go
+++ b/pkg/bundle/files.go
@@ -5,22 +5,22 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/RedHatGov/bundle/pkg/config"
 	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
 )
 
-// ReconcileFiles gather all files that were collected during a run
+// ReconcileManifest gather all manifests that were collected during a run
 // and checks against the current list
-func ReconcileFiles(meta *v1alpha1.Metadata, rootDir string) (newFiles []string, err error) {
+func ReconcileManifests(meta *v1alpha1.Metadata, sourceDir string) error {
 
-	foundFiles := make(map[string]struct{}, len(meta.PastFiles))
-	for _, pf := range meta.PastFiles {
+	foundFiles := make(map[string]struct{}, len(meta.PastManifests))
+	for _, pf := range meta.PastManifests {
 		foundFiles[pf.Name] = struct{}{}
 	}
+
 	// Ignore the current dir.
 	foundFiles["."] = struct{}{}
 
-	err = filepath.Walk(rootDir, func(fpath string, info os.FileInfo, err error) error {
+	return filepath.Walk("v2", func(fpath string, info os.FileInfo, err error) error {
 
 		if err != nil {
 			return fmt.Errorf("traversing %s: %v", fpath, err)
@@ -29,21 +29,82 @@ func ReconcileFiles(meta *v1alpha1.Metadata, rootDir string) (newFiles []string,
 			return fmt.Errorf("no file info")
 		}
 
-		file := v1alpha1.File{
+		if info.IsDir() && info.Name() == "blobs" {
+			return filepath.SkipDir
+		}
+
+		// TODO: figure a robust way to get the namespace from the path
+		file := v1alpha1.Manifest{
 			Name: fpath,
 		}
 
 		if _, found := foundFiles[fpath]; !found {
+
 			// Past files should only be image data, not tool metadata.
-			if base := filepath.Base(fpath); base != config.MetadataFile && base != config.AssociationsFile {
-				meta.PastFiles = append(meta.PastFiles, file)
-			}
 			foundFiles[fpath] = struct{}{}
-			newFiles = append(newFiles, fpath)
+			meta.PastManifests = append(meta.PastManifests, file)
+
+			// Make manifest dir in target
+			targetPath := filepath.Join(sourceDir, "manifests", filepath.Dir(fpath))
+			if err := os.MkdirAll(targetPath, os.ModePerm); err != nil {
+				return err
+			}
+
+			// Move new manifest to manifests directory
+			if info.Mode().IsRegular() {
+
+				if err := os.Rename(fpath, filepath.Join(targetPath, info.Name())); err != nil {
+					return err
+				}
+			}
+
 		}
 
 		return nil
 	})
+}
 
-	return newFiles, err
+// ReconcileBlobs gather all blobs that were collected during a run
+// and checks against the current list
+func ReconcileBlobs(meta *v1alpha1.Metadata, sourceDir string) error {
+
+	foundFiles := make(map[string]struct{}, len(meta.PastBlobs))
+	for _, pf := range meta.PastBlobs {
+		foundFiles[pf.Name] = struct{}{}
+	}
+
+	// Ignore the current dir.
+	foundFiles["."] = struct{}{}
+
+	return filepath.Walk("v2", func(fpath string, info os.FileInfo, err error) error {
+
+		if err != nil {
+			return fmt.Errorf("traversing %s: %v", fpath, err)
+		}
+		if info == nil {
+			return fmt.Errorf("no file info")
+		}
+
+		if info.IsDir() && info.Name() == "manifests" {
+			return filepath.SkipDir
+		}
+
+		if info.Mode().IsRegular() {
+			file := v1alpha1.Blob{
+				Name: info.Name(),
+			}
+
+			if _, found := foundFiles[info.Name()]; !found {
+				meta.PastBlobs = append(meta.PastBlobs, file)
+				foundFiles[fpath] = struct{}{}
+
+				// Move blob to blobs directory
+				if err := os.Rename(fpath, filepath.Join(sourceDir, "blobs", info.Name())); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	})
 }

--- a/pkg/bundle/files.go
+++ b/pkg/bundle/files.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
+	"github.com/sirupsen/logrus"
 )
 
 // ReconcileManifest gather all manifests that were collected during a run
@@ -54,6 +55,8 @@ func ReconcileManifests(meta *v1alpha1.Metadata, sourceDir string) error {
 			// Move new manifest to manifests directory
 			if info.Mode().IsRegular() {
 
+				logrus.Debugf("Adding manifest %s", fpath)
+
 				// Copy blob to blobs directory
 				input, err := ioutil.ReadFile(fpath)
 				if err != nil {
@@ -65,6 +68,8 @@ func ReconcileManifests(meta *v1alpha1.Metadata, sourceDir string) error {
 				}
 			}
 
+		} else {
+			logrus.Debugf("Manifest %s exists in imageset, skipping...", fpath)
 		}
 
 		return nil
@@ -103,7 +108,9 @@ func ReconcileBlobs(meta *v1alpha1.Metadata, sourceDir string) error {
 
 			if _, found := foundFiles[info.Name()]; !found {
 				meta.PastBlobs = append(meta.PastBlobs, file)
-				foundFiles[fpath] = struct{}{}
+				foundFiles[info.Name()] = struct{}{}
+
+				logrus.Debugf("Adding blob %s", info.Name())
 
 				// Copy blob to blobs directory
 				input, err := ioutil.ReadFile(fpath)
@@ -115,6 +122,8 @@ func ReconcileBlobs(meta *v1alpha1.Metadata, sourceDir string) error {
 					return err
 				}
 
+			} else {
+				logrus.Debugf("Blob %s exists in imageset, skipping...", info.Name())
 			}
 		}
 

--- a/pkg/bundle/files_test.go
+++ b/pkg/bundle/files_test.go
@@ -35,7 +35,6 @@ func Test_ReconcilingBlobs(t *testing.T) {
 				},
 			},
 			want: []v1alpha1.Blob{
-				{Name: "test1"},
 				{Name: "test3"},
 			},
 		},
@@ -82,16 +81,14 @@ func Test_ReconcilingBlobs(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := ReconcileBlobs(&meta, "."); err != nil {
+		actual, err := ReconcileBlobs(meta, ".")
+
+		if err != nil {
 			t.Fatal(err)
 		}
 
-		if !reflect.DeepEqual(meta.PastBlobs, tt.want) {
-			t.Errorf("Test %s: Expected '%v', got '%v'", tt.name, tt.want, meta.PastBlobs)
-		}
-
-		if _, err := os.Stat("blobs/test3"); err != nil {
-			t.Fatal(err)
+		if !reflect.DeepEqual(actual, tt.want) {
+			t.Errorf("Test %s: Expected '%v', got '%v'", tt.name, tt.want, actual)
 		}
 
 	}
@@ -123,9 +120,6 @@ func Test_ReconcilingManifest(t *testing.T) {
 				},
 			},
 			want: []v1alpha1.Manifest{
-				{Name: "v2"},
-				{Name: "v2/manifests"},
-				{Name: "v2/manifests/test1"},
 				{Name: "v2/manifests/test2"},
 			},
 		},
@@ -170,16 +164,14 @@ func Test_ReconcilingManifest(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := ReconcileManifests(&meta, "."); err != nil {
+		actual, err := ReconcileManifests(meta, ".")
+
+		if err != nil {
 			t.Fatal(err)
 		}
 
-		if !reflect.DeepEqual(meta.PastManifests, tt.want) {
-			t.Errorf("Test %s: Expected '%v', got '%v'", tt.name, tt.want, meta.PastManifests)
-		}
-
-		if _, err := os.Stat("manifests/v2/manifests/test2"); err != nil {
-			t.Fatal(err)
+		if !reflect.DeepEqual(actual, tt.want) {
+			t.Errorf("Test %s: Expected '%v', got '%v'", tt.name, tt.want, actual)
 		}
 
 	}

--- a/pkg/bundle/files_test.go
+++ b/pkg/bundle/files_test.go
@@ -3,35 +3,47 @@ package bundle
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/RedHatGov/bundle/pkg/config/v1alpha1"
 )
 
-func Test_ReconcilingFiles(t *testing.T) {
+func Test_ReconcilingBlobs(t *testing.T) {
+
+	paths := []string{
+		filepath.Join("v2", "blobs"),
+		filepath.Join("v2", "manifests"),
+		"blobs",
+		"internal",
+	}
+
 	type fields struct {
-		files []v1alpha1.File
+		files []v1alpha1.Blob
 	}
 	tests := []struct {
 		name   string
 		fields fields
-		want   []string
+		want   []v1alpha1.Blob
 	}{
 		{
-			name: "testing want to block",
+			name: "testing pulling new blobs",
 			fields: fields{
-				files: []v1alpha1.File{
+				files: []v1alpha1.Blob{
 					{Name: "test1"},
 				},
 			},
-			want: []string{"test2"},
+			want: []v1alpha1.Blob{
+				{Name: "test1"},
+				{Name: "test3"},
+			},
 		},
 	}
 	for _, tt := range tests {
 		meta := v1alpha1.Metadata{
 			MetadataSpec: v1alpha1.MetadataSpec{
-				PastFiles: tt.fields.files,
+				PastBlobs: tt.fields.files,
 			},
 		}
 
@@ -49,23 +61,125 @@ func Test_ReconcilingFiles(t *testing.T) {
 
 		defer os.Chdir(cwd)
 
+		for _, path := range paths {
+			if err := os.MkdirAll(path, os.ModePerm); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Write files
 		d1 := []byte("hello\ngo\n")
-		if err := ioutil.WriteFile("test2", d1, 0644); err != nil {
+		if err := ioutil.WriteFile("v2/test1", d1, 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := ioutil.WriteFile("internal/test2", d1, 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := ioutil.WriteFile("v2/test3", d1, 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := ioutil.WriteFile("v2/manifests/test4", d1, 0644); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := ioutil.WriteFile("test1", d1, 0644); err != nil {
+		if err := ReconcileBlobs(&meta, "."); err != nil {
 			t.Fatal(err)
 		}
 
-		actual, err := ReconcileFiles(&meta, ".")
+		if !reflect.DeepEqual(meta.PastBlobs, tt.want) {
+			t.Errorf("Test %s: Expected '%v', got '%v'", tt.name, tt.want, meta.PastBlobs)
+		}
+
+		if _, err := os.Stat("blobs/test3"); err != nil {
+			t.Fatal(err)
+		}
+
+	}
+}
+
+func Test_ReconcilingManifest(t *testing.T) {
+
+	paths := []string{
+		filepath.Join("v2", "blobs"),
+		filepath.Join("v2", "manifests"),
+		"manifests",
+	}
+
+	type fields struct {
+		files []v1alpha1.Manifest
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []v1alpha1.Manifest
+	}{
+		{
+			name: "testing new manifests",
+			fields: fields{
+				files: []v1alpha1.Manifest{
+					{Name: "v2"},
+					{Name: "v2/manifests"},
+					{Name: "v2/manifests/test1"},
+				},
+			},
+			want: []v1alpha1.Manifest{
+				{Name: "v2"},
+				{Name: "v2/manifests"},
+				{Name: "v2/manifests/test1"},
+				{Name: "v2/manifests/test2"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		meta := v1alpha1.Metadata{
+			MetadataSpec: v1alpha1.MetadataSpec{
+				PastManifests: tt.fields.files,
+			},
+		}
+
+		tmpdir := t.TempDir()
+
+		cwd, err := os.Getwd()
 
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if !reflect.DeepEqual(actual, tt.want) {
-			t.Errorf("Test %s: Expected '%v', got '%v'", tt.name, tt.want, actual)
+		if err := os.Chdir(tmpdir); err != nil {
+			t.Fatal(err)
+		}
+
+		defer os.Chdir(cwd)
+
+		// Write out blobs directroy to ensure these files are skipped
+		for _, path := range paths {
+			if err := os.MkdirAll(path, os.ModePerm); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Wtie files
+		d1 := []byte("hello\ngo\n")
+		if err := ioutil.WriteFile("v2/manifests/test1", d1, 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := ioutil.WriteFile("v2/manifests/test2", d1, 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := ioutil.WriteFile("v2/blobs/test3", d1, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := ReconcileManifests(&meta, "."); err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(meta.PastManifests, tt.want) {
+			t.Errorf("Test %s: Expected '%v', got '%v'", tt.name, tt.want, meta.PastManifests)
+		}
+
+		if _, err := os.Stat("manifests/v2/manifests/test2"); err != nil {
+			t.Fatal(err)
 		}
 
 	}

--- a/pkg/bundle/init.go
+++ b/pkg/bundle/init.go
@@ -36,8 +36,6 @@ func MakeCreateDirs(rootDir string) error {
 	paths := []string{
 		filepath.Join(config.SourceDir, config.PublishDir),
 		filepath.Join(config.SourceDir, "v2"),
-		filepath.Join(config.SourceDir, "blobs"),
-		filepath.Join(config.SourceDir, "manifests"),
 	}
 	for _, p := range paths {
 		dir := filepath.Join(rootDir, p)

--- a/pkg/bundle/init.go
+++ b/pkg/bundle/init.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/RedHatGov/bundle/pkg/config"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,10 +34,10 @@ func ValidateCreateDir(rootDir string) error {
 */
 func MakeCreateDirs(rootDir string) error {
 	paths := []string{
-		filepath.Join("bundle", "publish"),
-		filepath.Join("bundle", "v2"),
-		filepath.Join("src", "publish"),
-		filepath.Join("src", "v2"),
+		filepath.Join(config.SourceDir, config.PublishDir),
+		filepath.Join(config.SourceDir, "v2"),
+		filepath.Join(config.SourceDir, "blobs"),
+		filepath.Join(config.SourceDir, "manifests"),
 	}
 	for _, p := range paths {
 		dir := filepath.Join(rootDir, p)

--- a/pkg/config/v1alpha1/metadata_types.go
+++ b/pkg/config/v1alpha1/metadata_types.go
@@ -29,14 +29,16 @@ type MetadataSpec struct {
 	PastMirrors PastMirrors `json:"pastMirrors"`
 	// PastFiles is a slice containing information for
 	// all files created for an imageset
-	PastFiles []File `json:"pastFiles"`
+	PastBlobs     []Blob     `json:"pastBlobs"`
+	PastManifests []Manifest `json:"pastManifests"`
 }
 
 type PastMirror struct {
-	Timestamp int    `json:"timestamp"`
-	Sequence  int    `json:"sequence"`
-	Files     []File `json:"files"`
-	Mirror    Mirror `json:"mirror"`
+	Timestamp int        `json:"timestamp"`
+	Sequence  int        `json:"sequence"`
+	Manifests []Manifest `json:"manifests"`
+	Blobs     []Blob     `json:"blobs"`
+	Mirror    Mirror     `json:"mirror"`
 	// Operators are metadata about the set of mirrored operators in a mirror operation.
 	Operators []OperatorMetadata `json:"operators,omitempty"`
 }
@@ -50,8 +52,14 @@ func (pms PastMirrors) Len() int           { return len(pms) }
 func (pms PastMirrors) Swap(i, j int)      { pms[i], pms[j] = pms[j], pms[i] }
 func (pms PastMirrors) Less(i, j int) bool { return pms[i].Sequence < pms[j].Sequence }
 
-type File struct {
+type Blob struct {
 	Name string `json:"name"`
+}
+
+type Manifest struct {
+	Name      string `json:"name"`
+	Image     string `json:"image"`
+	Namespace string `json:"namespace"`
 }
 
 // OperatorMetadata holds an Operator's post-mirror metadata.

--- a/pkg/config/v1alpha1/testdata/metadata/valid.json
+++ b/pkg/config/v1alpha1/testdata/metadata/valid.json
@@ -42,7 +42,7 @@
           ]
         }
       },
-      "files": [
+      "blobs": [
         {
           "name": "sha256:fc07c1e2a5f012320ae672ca8546ff0d09eb8dba3c5acbbfc426c7984169ee84"
         },
@@ -101,7 +101,7 @@
           ]
         }
       },
-      "files": [
+      "blobs": [
         {
           "name": "sha256:fc07c1e2a5f012320ae672ca8546ff0d09eb8dba3c5acbbfc426c7984169ee33"
         },

--- a/test/e2e-simple.sh
+++ b/test/e2e-simple.sh
@@ -30,10 +30,10 @@ trap "${DIR}/stop-docker-registry.sh $REGISTRY_CONN; ${DIR}/stop-docker-registry
 "${DIR}/operator/setup-testdata.sh" "$DATA_TMP" "$CREATE_FULL_DIR"
 
 run_cmd create full --dir "$CREATE_FULL_DIR" --config "${CREATE_FULL_DIR}/imageset-config.yaml" --output "$DATA_TMP"
-run_cmd publish --dir "$PUBLISH_FULL_DIR" --archive "${DATA_TMP}/bundle_000000.tar.gz" --to-mirror localhost:$REGISTRY_DISCONN_PORT
+run_cmd publish --dir "$PUBLISH_FULL_DIR" --archive "${DATA_TMP}/bundle_000000.tar" --to-mirror localhost:$REGISTRY_DISCONN_PORT
 
 # TODO: test `create diff` with new operator bundles and releases.
-# rm "${DATA_TMP}/bundle_000000.tar.gz"
+# rm "${DATA_TMP}/bundle_000000.tar"
 # mkdir -p "${CREATE_DIFF_DIR}/src/publish"
 # cp "${CREATE_FULL_DIR}/src/publish/.metadata.json" "${CREATE_DIFF_DIR}/src/publish/"
 # run_cmd create diff --dir "$CREATE_DIFF_DIR" --config "${CREATE_DIFF_DIR}/imageset-config.yaml" --output "$DATA_TMP"


### PR DESCRIPTION
Featured added:
- No longer tracking duplicates blobs
- Replace pastFiles  with pastManifest and pastBlobs
- Created a creator struct for main create functions
- Reconciling blobs and manifests separately 