### PR TITLE
fix: added a check for err being nil when casting an error

### DIFF
--- a/pkg/operator/mirror.go
+++ b/pkg/operator/mirror.go
@@ -423,11 +423,11 @@ func (o *MirrorOptions) associateDeclarativeConfigImageLayers(mappingDir string,
 		srcDir := filepath.Join(o.RootDestDir, config.SourceDir)
 		assocs, err := image.AssociateImageLayers(srcDir, imgMappings, images)
 		if err != nil {
-			if merr, ok := err.(*image.MirrorError); ok {
-				logrus.Warn(merr)
-			} else {
+			merr := &image.MirrorError{}
+			if !errors.As(err, &merr) {
 				return err
 			}
+			logrus.Warn(err)
 		}
 
 		allAssocs.Merge(assocs)

--- a/pkg/operator/mirror.go
+++ b/pkg/operator/mirror.go
@@ -422,10 +422,12 @@ func (o *MirrorOptions) associateDeclarativeConfigImageLayers(mappingDir string,
 
 		srcDir := filepath.Join(o.RootDestDir, config.SourceDir)
 		assocs, err := image.AssociateImageLayers(srcDir, imgMappings, images)
-		if merr, ok := err.(*image.MirrorError); ok {
-			logrus.Warn(merr)
-		} else {
-			return err
+		if err != nil {
+			if merr, ok := err.(*image.MirrorError); ok {
+				logrus.Warn(merr)
+			} else {
+				return err
+			}
 		}
 
 		allAssocs.Merge(assocs)

--- a/pkg/operator/mirror.go
+++ b/pkg/operator/mirror.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"


### PR DESCRIPTION
Fixed a bug when type casting an error in operator.go