### PR TITLE
feat(publish): feat/top level associations

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -219,6 +219,8 @@ func includeFile(fpath string) bool {
 
 // Copied from mholt archiver repo. Temporary and can
 // add back to repo
+// Changes include the additional of the excludePath variable and is
+// passed to the untarNext function
 func Unarchive(a Archiver, source, destination string, excludePaths []string) error {
 
 	if !fileExists(destination) {
@@ -287,6 +289,9 @@ func untarNext(a Archiver, destination string, exclude []string) error {
 		return fmt.Errorf("checking path traversal attempt: %v", errPath)
 	}
 
+	// Added change here to check if
+	// current path is in the exclusion
+	// list
 	for _, path := range exclude {
 		if within(path, header.Name) {
 			return nil

--- a/pkg/bundle/publish/publish.go
+++ b/pkg/bundle/publish/publish.go
@@ -376,7 +376,7 @@ func (o *Options) Run(ctx context.Context, cmd *cobra.Command, f kcmdutil.Factor
 		catOpts.DryRun = o.DryRun
 		catOpts.MaxPathComponents = 2
 		catOpts.SecurityOptions.Insecure = o.SkipTLS
-		catOpts.FilterOptions.FilterByOS = "linux/amd64"
+		catOpts.FilterOptions = imagemanifest.FilterOptions{FilterByOS: o.FilterByOS}
 		catOpts.MaxICSPSize = 250000
 
 		args := []string{

--- a/pkg/bundle/release.go
+++ b/pkg/bundle/release.go
@@ -245,6 +245,10 @@ func (o *ReleaseOptions) downloadMirror(secret []byte, toDir, from string) (imag
 		return nil, err
 	}
 	for k, assoc := range assocs {
+		if strings.Contains(assoc.Name, "ocp-release") {
+			assoc.TopLevel = true
+		}
+
 		assoc.Type = image.TypeOCPRelease
 		assocs[k] = assoc
 	}

--- a/pkg/cli/options.go
+++ b/pkg/cli/options.go
@@ -20,6 +20,7 @@ type RootOptions struct {
 	SkipTLS          bool
 	SkipVerification bool
 	SkipCleanup      bool
+	FilterByOS       string
 
 	logfileCleanup func()
 }
@@ -32,6 +33,7 @@ func (o *RootOptions) BindFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.SkipTLS, "skip-tls", false, "skip client-side TLS validation")
 	fs.BoolVar(&o.SkipVerification, "skip-verification", false, "skip digest verification")
 	fs.BoolVar(&o.SkipCleanup, "skip-cleanup", false, "skip removal of artifact directories")
+	fs.StringVar(&o.FilterByOS, "filter-by-os", "linux/amd64", "A regular expression to control which index image is picked when multiple variants are available")
 }
 
 func (o *RootOptions) LogfilePreRun(cmd *cobra.Command, _ []string) {

--- a/pkg/operator/mirror.go
+++ b/pkg/operator/mirror.go
@@ -425,6 +425,9 @@ func (o *MirrorOptions) associateDeclarativeConfigImageLayers(ctlgRef imagesourc
 		}
 
 		for k, assoc := range assocs {
+			if assoc.Name == ctlgRef.Ref.Exact() {
+				assoc.TopLevel = true
+			}
 			assoc.Type = typ
 			assocs[k] = assoc
 		}


### PR DESCRIPTION
Problem: 
- For catalogs and release, we need to identify the top level association to pass to the `oc mirror` Run function.

Solution: 
- Created a new field in Association to include a TopLevel bool. This value is set based on whether the manifest is an index or by 
the operators and release packages.

Notes:
- Also adds an unarchiving function with the ability to exclude files and directories (not a follow on PR/issue for unit tests)