### PR TITLE
feat: multimap associations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mholt/archiver/v3 v3.5.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
+	github.com/openshift/api v0.0.0-20210831091943-07e756545ac1
 	github.com/openshift/installer v0.16.1
 	github.com/openshift/library-go v0.0.0-20210831102543-1a08f0c3bd9a
 	github.com/openshift/oc v0.0.0-alpha.0.0.20210721184532-4df50be4d929
@@ -26,6 +27,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.22.1
 	k8s.io/cli-runtime v0.22.0
 	k8s.io/client-go v0.22.1

--- a/pkg/bundle/additional.go
+++ b/pkg/bundle/additional.go
@@ -24,7 +24,7 @@ func NewAdditionalOptions(ro cli.RootOptions) *AdditionalOptions {
 }
 
 // GetAdditional downloads specified images in the imageset-config.yaml under mirror.additonalImages
-func (o *AdditionalOptions) GetAdditional(_ v1alpha1.PastMirror, cfg v1alpha1.ImageSetConfiguration) (image.Associations, error) {
+func (o *AdditionalOptions) GetAdditional(_ v1alpha1.PastMirror, cfg v1alpha1.ImageSetConfiguration) (image.AssociationSet, error) {
 
 	opts := mirror.NewMirrorImageOptions(o.IOStreams)
 	opts.DryRun = o.DryRun

--- a/pkg/bundle/additional.go
+++ b/pkg/bundle/additional.go
@@ -88,13 +88,9 @@ func (o *AdditionalOptions) GetAdditional(_ v1alpha1.PastMirror, cfg v1alpha1.Im
 		return nil, err
 	}
 
-	assocs, err := image.AssociateImageLayers(opts.FileDir, assocMappings, images)
+	assocs, err := image.AssociateImageLayers(opts.FileDir, assocMappings, images, image.TypeGeneric)
 	if err != nil {
 		return nil, err
-	}
-	for k, assoc := range assocs {
-		assoc.Type = image.TypeGeneric
-		assocs[k] = assoc
 	}
 
 	return assocs, nil

--- a/pkg/bundle/create/create.go
+++ b/pkg/bundle/create/create.go
@@ -51,7 +51,7 @@ func (o *Options) RunFull(ctx context.Context) error {
 			Timestamp: int(time.Now().Unix()),
 		}
 
-		allAssocs := image.Associations{}
+		allAssocs := image.NewAssociations()
 
 		if len(cfg.Mirror.OCP.Channels) != 0 {
 			opts := bundle.NewReleaseOptions(*o.RootOptions)
@@ -113,7 +113,7 @@ func (o *Options) RunDiff(ctx context.Context) error {
 			Timestamp: int(time.Now().Unix()),
 		}
 
-		allAssocs := image.Associations{}
+		allAssocs := image.NewAssociations()
 
 		if len(cfg.Mirror.OCP.Channels) != 0 {
 			opts := bundle.NewReleaseOptions(*o.RootOptions)
@@ -260,7 +260,7 @@ func (o *Options) prepareArchive(cfg v1alpha1.ImageSetConfiguration, manifests [
 	packager := archive.NewPackager(manifests, blobs)
 
 	// Create tar archive
-	if err := packager.CreateSplitArchive(segSize, output, ".", "bundle"); err != nil {
+	if err := packager.CreateSplitArchive(segSize, output, ".", "bundle", o.SkipCleanup); err != nil {
 		return fmt.Errorf("failed to create archive: %v", err)
 	}
 

--- a/pkg/bundle/create/create.go
+++ b/pkg/bundle/create/create.go
@@ -51,7 +51,7 @@ func (o *Options) RunFull(ctx context.Context) error {
 			Timestamp: int(time.Now().Unix()),
 		}
 
-		allAssocs := image.NewAssociations()
+		allAssocs := image.AssociationSet{}
 
 		if len(cfg.Mirror.OCP.Channels) != 0 {
 			opts := bundle.NewReleaseOptions(*o.RootOptions)
@@ -113,7 +113,7 @@ func (o *Options) RunDiff(ctx context.Context) error {
 			Timestamp: int(time.Now().Unix()),
 		}
 
-		allAssocs := image.NewAssociations()
+		allAssocs := image.AssociationSet{}
 
 		if len(cfg.Mirror.OCP.Channels) != 0 {
 			opts := bundle.NewReleaseOptions(*o.RootOptions)
@@ -296,7 +296,7 @@ func (o *Options) getFiles(meta v1alpha1.Metadata) ([]v1alpha1.Manifest, []v1alp
 	return manifests, blobs, nil
 }
 
-func (o *Options) writeAssociations(assocs image.Associations) error {
+func (o *Options) writeAssociations(assocs image.AssociationSet) error {
 	assocPath := filepath.Join(o.Dir, config.SourceDir, config.AssociationsBasePath)
 	if err := os.MkdirAll(filepath.Dir(assocPath), 0755); err != nil {
 		return fmt.Errorf("mkdir image associations file: %v", err)

--- a/pkg/bundle/publish/manifests.go
+++ b/pkg/bundle/publish/manifests.go
@@ -1,0 +1,268 @@
+package publish
+
+import (
+	"fmt"
+	"hash/fnv"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Copied from https://github.com/openshift/oc/blob/5d8dfa1c2e8e7469d69d76f21e0a166a0de8663b/pkg/cli/admin/catalog/mirror.go#L549
+// Changes made are breaking ICSP and Catalog Source generation into difference functions
+func WriteICSP(out io.Writer, dir string, icsps [][]byte) error {
+
+	if err := ioutil.WriteFile(filepath.Join(dir, "imageContentSourcePolicy.yaml"), aggregateICSPs(icsps), os.ModePerm); err != nil {
+		return fmt.Errorf("error writing ImageContentSourcePolicy")
+	}
+
+	fmt.Fprintf(out, "wrote mirroring manifests to %s\n", dir)
+
+	return nil
+}
+
+func WriteCatalogSource(out io.Writer, source imagesource.TypedImageReference, dir string, mapping map[imagesource.TypedImageReference]imagesource.TypedImageReference) error {
+
+	catalogSource, err := generateCatalogSource(source, mapping)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filepath.Join(dir, fmt.Sprintf("catalogSource-%s.yaml", source.Ref.Name)), catalogSource, os.ModePerm); err != nil {
+		return fmt.Errorf("error writing CatalogSource")
+	}
+
+	fmt.Fprintf(out, "wrote mirroring manifests to %s\n", dir)
+
+	return nil
+}
+
+func GenerateICSP(out io.Writer, name string, byteLimit int, icspScope string, mapping map[imagesource.TypedImageReference]imagesource.TypedImageReference) ([]byte, error) {
+	registryMapping := getRegistryMapping(out, icspScope, mapping)
+	icsp := operatorv1alpha1.ImageContentSourcePolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: operatorv1alpha1.GroupVersion.String(),
+			Kind:       "ImageContentSourcePolicy"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: strings.Join(strings.Split(name, "/"), "-"),
+			Labels: map[string]string{
+				"operators.openshift.org/catalog": "true",
+			},
+		},
+		Spec: operatorv1alpha1.ImageContentSourcePolicySpec{
+			RepositoryDigestMirrors: []operatorv1alpha1.RepositoryDigestMirrors{},
+		},
+	}
+
+	for key := range registryMapping {
+		icsp.Spec.RepositoryDigestMirrors = append(icsp.Spec.RepositoryDigestMirrors, operatorv1alpha1.RepositoryDigestMirrors{
+			Source:  name,
+			Mirrors: []string{registryMapping[key]},
+		})
+		y, err := yaml.Marshal(icsp)
+		if err != nil {
+			return nil, fmt.Errorf("unable to marshal ImageContentSourcePolicy yaml: %v", err)
+		}
+
+		if len(y) > byteLimit {
+			if lenMirrors := len(icsp.Spec.RepositoryDigestMirrors); lenMirrors > 0 {
+				icsp.Spec.RepositoryDigestMirrors = icsp.Spec.RepositoryDigestMirrors[:lenMirrors-1]
+			}
+			break
+		}
+	}
+
+	// Create an unstructured object for removing creationTimestamp
+	unstructuredObj := unstructured.Unstructured{}
+	var err error
+	unstructuredObj.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&icsp)
+	if err != nil {
+		return nil, fmt.Errorf("error converting to unstructured: %v", err)
+	}
+	delete(unstructuredObj.Object["metadata"].(map[string]interface{}), "creationTimestamp")
+
+	icspExample, err := yaml.Marshal(unstructuredObj.Object)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal ImageContentSourcePolicy yaml: %v", err)
+	}
+
+	return icspExample, nil
+}
+
+func aggregateICSPs(icsps [][]byte) []byte {
+	aggregation := []byte{}
+	for _, icsp := range icsps {
+		aggregation = append(aggregation, []byte("---\n")...)
+		aggregation = append(aggregation, icsp...)
+	}
+	return aggregation
+}
+
+func getRegistryMapping(out io.Writer, icspScope string, mapping map[imagesource.TypedImageReference]imagesource.TypedImageReference) map[string]string {
+	registryMapping := map[string]string{}
+	for k, v := range mapping {
+		if len(v.Ref.ID) == 0 {
+			fmt.Fprintf(out, "no digest mapping available for %s, skip writing to ImageContentSourcePolicy\n", k)
+			continue
+		}
+		if icspScope == "registry" {
+			registryMapping[k.Ref.Registry] = v.Ref.Registry
+		} else {
+			registryMapping[k.Ref.AsRepository().String()] = v.Ref.AsRepository().String()
+		}
+	}
+	return registryMapping
+}
+
+func generateCatalogSource(source imagesource.TypedImageReference, mapping map[imagesource.TypedImageReference]imagesource.TypedImageReference) ([]byte, error) {
+	dest, ok := mapping[source]
+	if !ok {
+		return nil, fmt.Errorf("no mapping found for index image")
+	}
+	unstructuredObj := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "operators.coreos.com/v1alpha1",
+			"kind":       "CatalogSource",
+			"metadata": map[string]interface{}{
+				"name":      source.Ref.Name,
+				"namespace": "openshift-marketplace",
+			},
+			"spec": map[string]interface{}{
+				"sourceType": "grpc",
+				"image":      dest.String(),
+			},
+		},
+	}
+	csExample, err := yaml.Marshal(unstructuredObj.Object)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal CatalogSource yaml: %v", err)
+	}
+
+	return csExample, nil
+}
+
+// Copied from https://github.com/openshift/oc/blob/183090787d00d5150440dd75d71b00a72739a86c/pkg/cli/admin/catalog/mirrorer.go#L45
+// Only used to create manifest mapping without actually mirroring
+func mappingForImages(images map[string]struct{}, src, dest imagesource.TypedImageReference, maxComponents int) (mapping map[imagesource.TypedImageReference]imagesource.TypedImageReference, errs []error) {
+	if dest.Type != imagesource.DestinationRegistry {
+		// don't do any name mangling when not mirroring to a real registry
+		// this allows us to assume the names are preserved when doing multi-hop mirrors that use a file or s3 as an
+		// intermediate step
+		maxComponents = 0
+
+		// if mirroring a source (like quay.io/my/index:1) to a file location like file://local/store
+		// we will remount all of the content in the file store under the catalog name
+		// i.e. file://local/store/my/index
+		var err error
+		dest, err = mount(src, dest, 0)
+		if err != nil {
+			errs = []error{err}
+			return
+		}
+	}
+
+	mapping = map[imagesource.TypedImageReference]imagesource.TypedImageReference{}
+	for img := range images {
+		if img == "" {
+			continue
+		}
+
+		parsed, err := imagesource.ParseReference(img)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("couldn't parse image for mirroring (%s), skipping mirror: %v", img, err))
+			continue
+		}
+
+		targetRef, err := mount(parsed, dest, maxComponents)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		// set docker defaults, but don't set default tag for digest refs
+		s := parsed
+		parsed.Ref = parsed.Ref.DockerClientDefaults()
+		if len(s.Ref.Tag) == 0 && len(s.Ref.ID) > 0 {
+			parsed.Ref.Tag = ""
+		}
+
+		// if src is a file store, assume all other references are in the same location on disk
+		if src.Type != imagesource.DestinationRegistry {
+			srcRef, err := mount(parsed, src, 0)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if len(parsed.Ref.Tag) == 0 {
+				srcRef.Ref.Tag = ""
+			}
+			mapping[srcRef] = targetRef
+			continue
+		}
+
+		mapping[parsed] = targetRef
+	}
+	return
+}
+
+func mount(in, dest imagesource.TypedImageReference, maxComponents int) (out imagesource.TypedImageReference, err error) {
+	out = in
+	out.Type = dest.Type
+
+	hasher := fnv.New32a()
+	// tag with hash of source ref if no tag given
+	if len(out.Ref.Tag) == 0 && len(out.Ref.ID) > 0 {
+		hasher.Reset()
+		_, err = hasher.Write([]byte(out.Ref.String()))
+		if err != nil {
+			err = fmt.Errorf("couldn't generate tag for image (%s), skipping mirror", in.String())
+		}
+		out.Ref.Tag = fmt.Sprintf("%x", hasher.Sum32())
+	}
+
+	// fill in default registry / tag if missing
+	out.Ref = out.Ref.DockerClientDefaults()
+
+	components := []string{}
+	if len(dest.Ref.Namespace) > 0 {
+		components = append(components, dest.Ref.Namespace)
+	}
+	if len(dest.Ref.Name) > 0 {
+		components = append(components, strings.Split(dest.Ref.Name, "/")...)
+	}
+	if len(out.Ref.Namespace) > 0 {
+		components = append(components, out.Ref.Namespace)
+	}
+	if len(out.Ref.Name) > 0 {
+		components = append(components, strings.Split(out.Ref.Name, "/")...)
+	}
+
+	out.Ref.Registry = dest.Ref.Registry
+	out.Ref.Namespace = components[0]
+	if maxComponents > 1 && len(components) > maxComponents {
+		out.Ref.Name = strings.Join(components[1:maxComponents-1], "/") + "/" + strings.Join(components[maxComponents-1:], "-")
+	} else if maxComponents == 0 {
+		out.Ref.Name = strings.Join(components[1:], "/")
+	} else if len(components) > 1 {
+		endIndex := maxComponents
+		if endIndex > len(components) {
+			endIndex = len(components)
+		}
+
+		out.Ref.Name = strings.Join(components[1:endIndex], "/")
+	} else {
+		// only one component, make it the name, not the namespace
+		out.Ref.Name = in.Ref.Name
+		out.Ref.Namespace = ""
+	}
+	out.Ref.Name = strings.TrimPrefix(out.Ref.Name, "/")
+	return
+}

--- a/pkg/bundle/publish/options.go
+++ b/pkg/bundle/publish/options.go
@@ -13,6 +13,8 @@ type Options struct {
 
 	ArchivePath string
 	ToMirror    string
+
+	tmp string
 }
 
 func (o *Options) BindFlags(fs *pflag.FlagSet) {

--- a/pkg/bundle/publish/publish.go
+++ b/pkg/bundle/publish/publish.go
@@ -10,13 +10,13 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/mholt/archiver/v3"
 	"github.com/opencontainers/go-digest"
 	"github.com/openshift/library-go/pkg/image/reference"
 	"github.com/openshift/library-go/pkg/image/registryclient"
-	"github.com/openshift/oc/pkg/cli/admin/catalog"
 	"github.com/openshift/oc/pkg/cli/admin/release"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	imagemanifest "github.com/openshift/oc/pkg/cli/image/manifest"
@@ -73,27 +73,17 @@ func (o *Options) Run(ctx context.Context, cmd *cobra.Command, f kcmdutil.Factor
 	}
 
 	// Create workspace
-	tmpdir, err := ioutil.TempDir(o.Dir, "imageset")
+	cleanup, err := o.mktempDir()
 	if err != nil {
 		return err
 	}
 
 	// Handle cleanup of disk
-	defer func() {
-		if err := os.RemoveAll(tmpdir); err != nil {
-			logrus.Fatal(err)
-		}
-	}()
-
 	if !o.SkipCleanup {
-		defer func() {
-			if err := os.RemoveAll(filepath.Join(o.Dir, "v2")); err != nil {
-				logrus.Fatal(err)
-			}
-		}()
+		defer cleanup()
 	}
 
-	logrus.Debugf("Using temporary directory %s to unarchive metadata", tmpdir)
+	logrus.Debugf("Using temporary directory %s to unarchive metadata", o.tmp)
 
 	// Get file information from the source archives
 	filesInArchive, err := o.readImageSet(a)
@@ -102,7 +92,7 @@ func (o *Options) Run(ctx context.Context, cmd *cobra.Command, f kcmdutil.Factor
 	}
 
 	// Extract incoming metadata
-	if err := unpack(config.MetadataBasePath, tmpdir, filesInArchive); err != nil {
+	if err := unpack(config.MetadataBasePath, o.tmp, filesInArchive); err != nil {
 		return err
 	}
 
@@ -113,7 +103,7 @@ func (o *Options) Run(ctx context.Context, cmd *cobra.Command, f kcmdutil.Factor
 	}
 
 	// Create a local workspace backend
-	workspace, err := storage.NewLocalBackend(tmpdir)
+	workspace, err := storage.NewLocalBackend(o.tmp)
 	if err != nil {
 		return fmt.Errorf("error opening local backend: %v", err)
 	}
@@ -163,7 +153,6 @@ func (o *Options) Run(ctx context.Context, cmd *cobra.Command, f kcmdutil.Factor
 		}
 	}
 
-	// Unarchive full imageset after metadata checks
 	if err := o.unpackImageSet(a, o.Dir); err != nil {
 		return err
 	}
@@ -185,223 +174,187 @@ func (o *Options) Run(ctx context.Context, cmd *cobra.Command, f kcmdutil.Factor
 
 	var (
 		errs []error
-		// Mappings for mirroring image types.
-		genericMappings []imgmirror.Mapping
-		releaseMappings []imgmirror.Mapping
-		catalogMappings []imgmirror.Mapping
-
 		// Map of remote layer digest to the set of paths they should be fetched to.
-		missingLayers = map[string][]string{}
-		aerr          = &ErrArchiveFileNotFound{}
+		aerr  = &ErrArchiveFileNotFound{}
+		icsps [][]byte
 	)
 
-	for imageName, assoc := range assocs {
-
-		assoc := assoc
-		logrus.Debugf("reading assoc: %s", assoc.Name)
-
-		// All manifest layers will be pulled below if associated,
-		// so just sanity-check that the layers are referenced in some association.
-		if len(assoc.ManifestDigests) != 0 {
-			for _, manifestDigest := range assoc.ManifestDigests {
-				if _, hasManifest := assocs[manifestDigest]; !hasManifest {
-					errs = append(errs, fmt.Errorf("image %q: expected associations to have manifest %s but was not found", imageName, manifestDigest))
-				}
-			}
-		}
-
-		for _, layerDigest := range assoc.LayerDigests {
-			logrus.Debugf("Found layer %v for image %s", layerDigest, imageName)
-			// Construct blob path, which is adjacent to the manifests path.
-			blobPath := filepath.Join("blobs", layerDigest)
-			imagePath := filepath.Join(o.Dir, "v2", assoc.Path)
-			imageBlobPath := filepath.Join(imagePath, blobPath)
-			switch err := unpack(blobPath, imagePath, filesInArchive); {
-			case err == nil:
-				logrus.Debugf("Blob %s found in %s", layerDigest, assoc.Path)
-			case errors.As(err, &os.ErrNotExist) || errors.As(err, &aerr):
-				// Image layer must exist in the mirror registry since it wasn't archived,
-				// so fetch the layer and place it in the blob dir so it can be mirrored by `oc`.
-				missingLayers[layerDigest] = append(missingLayers[layerDigest], imageBlobPath)
-			default:
-				errs = append(errs, fmt.Errorf("accessing image %q blob %q at %s: %v", imageName, layerDigest, blobPath, err))
-			}
-		}
-
-		m := imgmirror.Mapping{Name: assoc.Name}
-		if m.Source, err = imagesource.ParseReference("file://" + assoc.Path); err != nil {
-			errs = append(errs, fmt.Errorf("error parsing source ref %q: %v", assoc.Path, err))
-			continue
-		}
-		// The mirrorer is not a fan of accepting an image ID when a tag symlink is available
-		// for some reason.
-		// TODO(estroz): investigate the cause of this behavior.
-		if assoc.TagSymlink == "" {
-			m.Source.Ref.ID = assoc.ID
-		} else {
-			m.Source.Ref.Tag = assoc.TagSymlink
-		}
-		m.Destination = toMirrorRef
-		m.Destination.Ref.Namespace = m.Source.Ref.Namespace
-		m.Destination.Ref.Name = m.Source.Ref.Name
-		m.Destination.Ref.Tag = m.Source.Ref.Tag
-		m.Destination.Ref.ID = m.Source.Ref.ID
-
-		switch assoc.Type {
-		case image.TypeGeneric:
-			genericMappings = append(genericMappings, m)
-		case image.TypeOCPRelease:
-			m.Destination.Ref.Tag = ""
-			m.Destination.Ref.ID = ""
-			if assoc.TopLevel {
-				releaseMappings = append(releaseMappings, m)
-			}
-		case image.TypeOperatorCatalog:
-			if assoc.TopLevel {
-				catalogMappings = append(catalogMappings, m)
-			} else {
-				logrus.Infof("skipping %v", assoc)
-			}
-		case image.TypeOperatorBundle, image.TypeOperatorRelatedImage:
-			// Let the `catalog mirror` API call mirror all bundle and related images in the catalog.
-			// TODO(estroz): this may be incorrect if bundle and related images not in a catalog can be archived,
-			// ex. as an additional image. Can probably get around this by mirroring
-			// images of this type not mapped by preceding `catalog mirror` calls.
-		case image.TypeInvalid:
-			errs = append(errs, fmt.Errorf("image %q: image type is not set", imageName))
-		default:
-			errs = append(errs, fmt.Errorf("image %q: invalid image type %v", imageName, assoc.Type))
-		}
-	}
-	if len(errs) != 0 {
-		return utilerrors.NewAggregate(errs)
-	}
-
-	if len(missingLayers) != 0 {
-		// Fetch all layers and mount them at the specified paths.
-		if err := o.fetchBlobs(ctx, incomingMeta, catalogMappings, missingLayers); err != nil {
-			return err
-		}
-	}
-
-	// Now that all layers have been pulled, symlink all tagged manifests to their digest files.
-	for _, assoc := range assocs {
-		if assoc.TagSymlink == "" {
-			continue
-		}
-		manifestsPath := filepath.Join(o.Dir, "v2", assoc.Path, "manifests")
-		dstPath := filepath.Join(manifestsPath, assoc.TagSymlink)
-
-		if _, err := os.Stat(dstPath); err == nil || errors.Is(err, os.ErrExist) {
-			logrus.Debugf("image %s: tag %s symlink for manifest %s already exists", assoc.Name, assoc.TagSymlink, assoc.ID)
-			continue
-		}
-		if err := os.Symlink(assoc.ID, dstPath); err != nil {
-			errs = append(errs, fmt.Errorf("error symlinking manifest digest %q to tag %q: %v", assoc.ID, assoc.TagSymlink, err))
-		}
-	}
-	if len(errs) != 0 {
-		return utilerrors.NewAggregate(errs)
-	}
-
-	// import imagecontentsourcepolicy
-	logrus.Info("ICSP importing not implemented")
-
-	// import catalogsource
-	logrus.Info("CatalogSource importing not implemented")
-
-	// Mirror all file sources of each available image type to mirror registry.
-	if len(genericMappings) != 0 {
-		if logrus.IsLevelEnabled(logrus.DebugLevel) {
-			var srcs []string
-			for _, m := range genericMappings {
-				srcs = append(srcs, m.Source.String())
-			}
-			logrus.Debugf("mirroring generic images: %q", srcs)
-		}
-		genOpts := imgmirror.NewMirrorImageOptions(o.IOStreams)
-		genOpts.Mappings = genericMappings
-		genOpts.DryRun = o.DryRun
-		genOpts.FromFileDir = o.Dir
-		genOpts.FilterOptions = imagemanifest.FilterOptions{FilterByOS: ".*"}
-		genOpts.SkipMultipleScopes = true
-		genOpts.KeepManifestList = true
-		genOpts.SecurityOptions.Insecure = o.SkipTLS
-		if err := genOpts.Validate(); err != nil {
-			return fmt.Errorf("invalid image mirror options: %v", err)
-		}
-		if err := genOpts.Run(); err != nil {
-			return fmt.Errorf("error running generic image mirror: %v", err)
-		}
-	}
-
-	for _, m := range releaseMappings {
-		logrus.Debugf("mirroring release image: %s", m.Source.String())
-		relOpts := release.NewMirrorOptions(o.IOStreams)
-		relOpts.From = m.Source.String()
-		relOpts.FromDir = o.Dir
-		relOpts.To = m.Destination.String()
-		relOpts.SecurityOptions.Insecure = o.SkipTLS
-		relOpts.DryRun = o.DryRun
-		if err := relOpts.Complete(cmd, f, nil); err != nil {
-			return fmt.Errorf("error initializing release mirror options: %v", err)
-		}
-		if err := relOpts.Validate(); err != nil {
-			return fmt.Errorf("invalid release mirror options: %v", err)
-		}
-		if err := relOpts.Run(); err != nil {
-			return fmt.Errorf("error running %q release mirror: %v", m, err)
-		}
-	}
-
-	// Change to the working dir since catalog mirroring does not respect
-	// FileDir in the "expected" manner (unclear why).
-	wd, err := os.Getwd()
+	// Create target dir for manifest directory
+	manifestDir, err := o.createManifestDir()
 	if err != nil {
 		return err
 	}
-	if err := os.Chdir(o.Dir); err != nil {
+
+	for _, imageName := range assocs.Keys() {
+
+		genericMappings := []imgmirror.Mapping{}
+		releaseMapping := imgmirror.Mapping{}
+		missingLayers := map[string][]string{}
+		icspMapping := make(map[imagesource.TypedImageReference]imagesource.TypedImageReference)
+
+		values, _ := assocs.Search(imageName)
+
+		// Create temp workspace for image processing
+		cleanup, err := o.mktempDir()
+		if err != nil {
+			return &image.ErrNoMapping{}
+		}
+
+		for _, assoc := range values {
+
+			manifestPath := filepath.Join("v2", assoc.Path, "manifests")
+
+			// Ensure child manifests are all unpacked
+			// TODO: find a way to ensure these will be process on their
+			// No longer stored in the map
+			logrus.Debugf("reading assoc: %s", assoc.Name)
+			if len(assoc.ManifestDigests) != 0 {
+				for _, manifestDigest := range assoc.ManifestDigests {
+					if hasManifest := assocs.SetContainsKey(imageName, manifestDigest); !hasManifest {
+						errs = append(errs, fmt.Errorf("image %q: expected associations to have manifest %s but was not found", imageName, manifestDigest))
+						continue
+					}
+					manifestArchivePath := filepath.Join(manifestPath, manifestDigest)
+					switch _, err := os.Stat(manifestPath); {
+					case err == nil:
+						logrus.Debugf("Manifest found %s found in %s", manifestDigest, assoc.Path)
+					case errors.Is(err, os.ErrNotExist):
+						if err := unpack(manifestArchivePath, o.tmp, filesInArchive); err != nil {
+							errs = append(errs, err)
+						}
+					default:
+						errs = append(errs, fmt.Errorf("accessing image %q manifest %q: %v", imageName, manifestDigest, err))
+					}
+				}
+			}
+
+			// Unpack association main manifest
+			if err := unpack(filepath.Join(manifestPath, assoc.ID), o.tmp, filesInArchive); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			for _, layerDigest := range assoc.LayerDigests {
+				logrus.Debugf("Found layer %v for image %s", layerDigest, imageName)
+				// Construct blob path, which is adjacent to the manifests path.
+				blobPath := filepath.Join("blobs", layerDigest)
+				imagePath := filepath.Join(o.tmp, "v2", assoc.Path)
+				imageBlobPath := filepath.Join(imagePath, blobPath)
+				switch err := unpack(blobPath, imagePath, filesInArchive); {
+				case err == nil:
+					logrus.Debugf("Blob %s found in %s", layerDigest, assoc.Path)
+				case errors.Is(err, os.ErrNotExist) || errors.As(err, &aerr):
+					// Image layer must exist in the mirror registry since it wasn't archived,
+					// so fetch the layer and place it in the blob dir so it can be mirrored by `oc`.
+					missingLayers[layerDigest] = append(missingLayers[layerDigest], imageBlobPath)
+				default:
+					errs = append(errs, fmt.Errorf("accessing image %q blob %q at %s: %v", imageName, layerDigest, blobPath, err))
+				}
+			}
+
+			m := imgmirror.Mapping{Name: assoc.Name}
+			if m.Source, err = imagesource.ParseReference("file://" + assoc.Path); err != nil {
+				errs = append(errs, fmt.Errorf("error parsing source ref %q: %v", assoc.Path, err))
+				continue
+			}
+			// The mirrorer is not a fan of accepting an image ID when a tag symlink is available
+			// for some reason.
+			// TODO(estroz): investigate the cause of this behavior.
+			if assoc.TagSymlink == "" {
+				m.Source.Ref.ID = assoc.ID
+			} else {
+				if err := unpack(filepath.Join(manifestPath, assoc.TagSymlink), o.tmp, filesInArchive); err != nil {
+					errs = append(errs, err)
+				}
+				m.Source.Ref.Tag = assoc.TagSymlink
+			}
+			m.Destination = toMirrorRef
+			m.Destination.Ref.Namespace = m.Source.Ref.Namespace
+			m.Destination.Ref.Name = m.Source.Ref.Name
+			m.Destination.Ref.Tag = m.Source.Ref.Tag
+			m.Destination.Ref.ID = m.Source.Ref.ID
+
+			if len(missingLayers) != 0 {
+				// Fetch all layers and mount them at the specified paths.
+				if err := o.fetchBlobs(ctx, incomingMeta, m, missingLayers); err != nil {
+					return err
+				}
+			}
+
+			switch assoc.Type {
+			case image.TypeGeneric:
+				genericMappings = append(genericMappings, m)
+			case image.TypeOCPRelease:
+				m.Destination.Ref.Tag = ""
+				m.Destination.Ref.ID = ""
+				if strings.Contains(assoc.Name, "ocp-release") {
+					releaseMapping = m
+				}
+			case image.TypeOperatorCatalog:
+				genericMappings = append(genericMappings, m)
+
+				// Create a catalog source file for index
+				mapping := make(map[imagesource.TypedImageReference]imagesource.TypedImageReference)
+				mapping[m.Source] = m.Destination
+				if err := o.writeCatalogSource(manifestDir, mapping); err != nil {
+					errs = append(errs, fmt.Errorf("image %q: writing catalog source %v", imageName, err))
+				}
+			case image.TypeOperatorBundle, image.TypeOperatorRelatedImage:
+				genericMappings = append(genericMappings, m)
+			case image.TypeInvalid:
+				errs = append(errs, fmt.Errorf("image %q: image type is not set", imageName))
+			default:
+				errs = append(errs, fmt.Errorf("image %q: invalid image type %v", imageName, assoc.Type))
+			}
+
+			// Add source to mapping if not a tag
+			if m.Source.Ref.Tag == "" {
+				icspMapping[m.Source] = m.Destination
+			}
+		}
+
+		// Mirror all generic mappings for this image
+		if len(genericMappings) != 0 {
+			if err := o.mirrorImage(genericMappings); err != nil {
+				errs = append(errs, err)
+			}
+
+			if !o.SkipCleanup {
+				cleanup()
+			}
+		}
+
+		// If this is a release image mirror the full release
+		if releaseMapping.Source.String() != "" {
+			if err := o.mirrorRelease(releaseMapping, cmd, f); err != nil {
+				errs = append(errs, err)
+			}
+
+			if !o.SkipCleanup {
+				cleanup()
+			}
+		}
+
+		// Generate image ICSP data
+		if len(icspMapping) != 0 {
+			icsp, err := GenerateICSP(os.Stdout, imageName, 250000, "repository", icspMapping)
+			if err != nil {
+				errs = append(errs, err)
+			}
+			icsps = append(icsps, icsp)
+		}
+	}
+	if len(errs) != 0 {
+		return utilerrors.NewAggregate(errs)
+	}
+
+	// Write an aggregation of ICSPs
+	if err := WriteICSP(os.Stdout, manifestDir, icsps); err != nil {
 		return err
 	}
-	defer func() {
-		if err := os.Chdir(wd); err != nil {
-			logrus.Error(err)
-		}
-	}()
 
-	for _, m := range catalogMappings {
-		logrus.Debugf("mirroring catalog image: %s", m.Source)
-
-		catOpts := catalog.NewMirrorCatalogOptions(o.IOStreams)
-		catOpts.DryRun = o.DryRun
-		catOpts.MaxPathComponents = 2
-		catOpts.SecurityOptions.Insecure = o.SkipTLS
-		catOpts.FilterOptions = imagemanifest.FilterOptions{FilterByOS: o.FilterByOS}
-		catOpts.MaxICSPSize = 250000
-
-		args := []string{
-			m.Source.String(),
-			o.ToMirror,
-		}
-		if err := catOpts.Complete(cmd, args); err != nil {
-			return fmt.Errorf("error constructing catalog options: %v", err)
-		}
-		if err := catOpts.Validate(); err != nil {
-			return fmt.Errorf("invalid catalog mirror options: %v", err)
-		}
-		if err := catOpts.Run(); err != nil {
-			return fmt.Errorf("error mirroring catalog: %v", err)
-		}
-	}
-	if err := os.Chdir(wd); err != nil {
-		return err
-	}
-
-	// install imagecontentsourcepolicy
-	logrus.Info("ICSP creation not implemented")
-
-	// install catalogsource
-	logrus.Info("CatalogSource creation not implemented")
+	// Install catalogsource and icsp
+	logrus.Info("CatalogSource and ICSP install not implemented")
 
 	// Replace old metadata with new metadata
 	if err := backend.WriteMetadata(ctx, &incomingMeta, config.MetadataBasePath); err != nil {
@@ -446,7 +399,7 @@ func (o *Options) unpackImageSet(a archive.Archiver, dest string) error {
 
 			if extension == a.String() {
 				logrus.Debugf("Extracting archive %s", path)
-				if err := archive.Unarchive(a, path, dest, []string{"blobs"}); err != nil {
+				if err := archive.Unarchive(a, path, dest, []string{"blobs", "v2"}); err != nil {
 					return err
 				}
 			}
@@ -460,13 +413,6 @@ func (o *Options) unpackImageSet(a archive.Archiver, dest string) error {
 		if err := archive.Unarchive(a, o.ArchivePath, dest, []string{"blobs"}); err != nil {
 			return err
 		}
-	}
-
-	// Workaround to save disk space.
-	// FIXME(jpower): need to create a function to skip directories
-	// during an unarchive
-	if err := os.RemoveAll(filepath.Join(dest, "blobs")); err != nil {
-		return err
 	}
 
 	return err
@@ -542,12 +488,10 @@ func copyBlobFile(src io.Reader, dstPath string) error {
 	return nil
 }
 
-func (o *Options) fetchBlobs(ctx context.Context, meta v1alpha1.Metadata, mappings []imgmirror.Mapping, missingLayers map[string][]string) error {
+func (o *Options) fetchBlobs(ctx context.Context, meta v1alpha1.Metadata, mapping imgmirror.Mapping, missingLayers map[string][]string) error {
 	catalogNamespaceNames := []string{}
-	for _, m := range mappings {
-		dstRef := m.Destination.Ref
-		catalogNamespaceNames = append(catalogNamespaceNames, path.Join(dstRef.Namespace, dstRef.Name))
-	}
+	dstRef := mapping.Destination.Ref
+	catalogNamespaceNames = append(catalogNamespaceNames, path.Join(dstRef.Namespace, dstRef.Name))
 
 	blobResources := map[string]string{}
 	for _, blob := range meta.PastBlobs {
@@ -646,4 +590,103 @@ func unpack(archiveFilePath, dest string, filesInArchive map[string]string) erro
 	}
 
 	return nil
+}
+
+func (o *Options) mktempDir() (func(), error) {
+	dir, err := ioutil.TempDir(o.Dir, "images")
+	o.tmp = dir
+	return func() {
+		if err := os.RemoveAll(dir); err != nil {
+			logrus.Fatal(err)
+		}
+		logrus.Debugf("Deleted temp directory %s", dir)
+	}, err
+}
+
+// mirrorRelease uses the `oc release mirror` library to mirror OCP release
+func (o *Options) mirrorRelease(mapping imgmirror.Mapping, cmd *cobra.Command, f kcmdutil.Factory) error {
+	logrus.Debugf("mirroring release image: %s", mapping.Source.String())
+	relOpts := release.NewMirrorOptions(o.IOStreams)
+	relOpts.From = mapping.Source.String()
+	relOpts.FromDir = o.tmp
+	relOpts.To = mapping.Destination.String()
+	relOpts.SecurityOptions.Insecure = o.SkipTLS
+	relOpts.DryRun = o.DryRun
+	if err := relOpts.Complete(cmd, f, nil); err != nil {
+		return fmt.Errorf("error initializing release mirror options: %v", err)
+	}
+	if err := relOpts.Validate(); err != nil {
+		return fmt.Errorf("invalid release mirror options: %v", err)
+	}
+	if err := relOpts.Run(); err != nil {
+		return fmt.Errorf("error running %q release mirror: %v", mapping, err)
+	}
+
+	return nil
+}
+
+// mirrorImages uses the `oc mirror` library to mirror generic images
+func (o *Options) mirrorImage(mappings []imgmirror.Mapping) error {
+	// Mirror all file sources of each available image type to mirror registry.
+	if logrus.IsLevelEnabled(logrus.DebugLevel) {
+		var srcs []string
+		for _, m := range mappings {
+			srcs = append(srcs, m.Source.String())
+		}
+		logrus.Debugf("mirroring generic images: %q", srcs)
+	}
+	genOpts := imgmirror.NewMirrorImageOptions(o.IOStreams)
+	genOpts.Mappings = mappings
+	genOpts.DryRun = o.DryRun
+	genOpts.FromFileDir = o.tmp
+	genOpts.FilterOptions = imagemanifest.FilterOptions{FilterByOS: ".*"}
+	genOpts.SkipMultipleScopes = true
+	genOpts.KeepManifestList = true
+	genOpts.SecurityOptions.Insecure = o.SkipTLS
+	if err := genOpts.Validate(); err != nil {
+		return fmt.Errorf("invalid image mirror options: %v", err)
+	}
+	if err := genOpts.Run(); err != nil {
+		return fmt.Errorf("error running generic image mirror: %v", err)
+	}
+
+	return nil
+}
+
+// writeCatalogSource will write a CatalogSource for catalog index
+func (o *Options) writeCatalogSource(manifestDir string, mapping map[imagesource.TypedImageReference]imagesource.TypedImageReference) error {
+	errs := []error{}
+	for source, dest := range mapping {
+		images := make(map[string]struct{})
+		images[dest.String()] = struct{}{}
+		mapping, mapErrs := mappingForImages(images, source, dest, 2)
+		if len(mapErrs) > 0 {
+			errs = append(errs, mapErrs...)
+		}
+
+		mappedIndex, err := mount(source, dest, 2)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		mapping[source] = mappedIndex
+
+		if err := WriteCatalogSource(os.Stdout, source, manifestDir, mapping); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func (o *Options) createManifestDir() (manifestDir string, err error) {
+	manifestDir = filepath.Join(
+		o.Dir,
+		fmt.Sprintf("manifest-%v", time.Now().Unix()),
+	)
+
+	if err := os.MkdirAll(manifestDir, os.ModePerm); err != nil {
+		return manifestDir, err
+	}
+
+	return manifestDir, nil
 }

--- a/pkg/bundle/release.go
+++ b/pkg/bundle/release.go
@@ -212,7 +212,7 @@ func (c Client) GetChannelLatest(ctx context.Context, uri *url.URL, arch string,
 	return new, err
 }
 
-func (o *ReleaseOptions) downloadMirror(secret []byte, toDir, from string) (image.Associations, error) {
+func (o *ReleaseOptions) downloadMirror(secret []byte, toDir, from string) (image.AssociationSet, error) {
 	opts := release.NewMirrorOptions(o.IOStreams)
 	opts.From = from
 	opts.ToDir = toDir
@@ -261,9 +261,9 @@ func (o *ReleaseOptions) downloadMirror(secret []byte, toDir, from string) (imag
 	return assocs, nil
 }
 
-func (o *ReleaseOptions) GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration) (image.Associations, error) {
+func (o *ReleaseOptions) GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration) (image.AssociationSet, error) {
 
-	allAssocs := image.NewAssociations()
+	allAssocs := image.AssociationSet{}
 	pullSecret := cfg.Mirror.OCP.PullSecret
 	srcDir := filepath.Join(o.Dir, config.SourceDir)
 
@@ -338,9 +338,9 @@ func (o *ReleaseOptions) GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration) 
 	return allAssocs, nil
 }
 
-func (o *ReleaseOptions) GetReleasesDiff(_ v1alpha1.PastMirror, cfg v1alpha1.ImageSetConfiguration) (image.Associations, error) {
+func (o *ReleaseOptions) GetReleasesDiff(_ v1alpha1.PastMirror, cfg v1alpha1.ImageSetConfiguration) (image.AssociationSet, error) {
 
-	allAssocs := image.NewAssociations()
+	allAssocs := image.AssociationSet{}
 	pullSecret := cfg.Mirror.OCP.PullSecret
 	srcDir := filepath.Join(o.Dir, config.SourceDir)
 

--- a/pkg/bundle/release.go
+++ b/pkg/bundle/release.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -36,6 +37,7 @@ import (
 // on a particular release image.
 type ReleaseOptions struct {
 	cli.RootOptions
+	release string
 }
 
 // NewReleaseOptions defaults ReleaseOptions.
@@ -220,7 +222,7 @@ func (o *ReleaseOptions) downloadMirror(secret []byte, toDir, from string) (imag
 	if len(secret) != 0 {
 		ctx, err := config.CreateContext(secret, o.SkipVerification, o.SkipTLS)
 		if err != nil {
-			return image.Associations{}, err
+			return nil, err
 		}
 		opts.SecurityOptions.CachedContext = ctx
 	}
@@ -230,27 +232,30 @@ func (o *ReleaseOptions) downloadMirror(secret []byte, toDir, from string) (imag
 	opts.DryRun = o.DryRun
 
 	if err := opts.Run(); err != nil {
-		return image.Associations{}, err
+		return nil, err
 	}
 
 	// Retrive the mapping information for release
 	mapping, images, err := o.getMapping(*opts)
 
 	if err != nil {
-		return image.Associations{}, fmt.Errorf("error could retrieve mapping information: %v", err)
+		return nil, fmt.Errorf("error could retrieve mapping information: %v", err)
 	}
 
-	assocs, err := image.AssociateImageLayers(toDir, mapping, images)
+	assocs, err := image.AssociateImageLayers(toDir, mapping, images, image.TypeOCPRelease)
 	if err != nil {
 		return nil, err
 	}
-	for k, assoc := range assocs {
-		if strings.Contains(assoc.Name, "ocp-release") {
-			assoc.TopLevel = true
-		}
 
-		assoc.Type = image.TypeOCPRelease
-		assocs[k] = assoc
+	// Check if a release image was provided with mapping
+	if o.release == "" {
+		return nil, errors.New("release image not found in mapping")
+	}
+
+	// Update all images associated with a release to the
+	// release images so they form one keyset for publising
+	for _, img := range images {
+		assocs.UpdateKey(img, o.release)
 	}
 
 	return assocs, nil
@@ -258,7 +263,7 @@ func (o *ReleaseOptions) downloadMirror(secret []byte, toDir, from string) (imag
 
 func (o *ReleaseOptions) GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration) (image.Associations, error) {
 
-	allAssocs := image.Associations{}
+	allAssocs := image.NewAssociations()
 	pullSecret := cfg.Mirror.OCP.PullSecret
 	srcDir := filepath.Join(o.Dir, config.SourceDir)
 
@@ -269,13 +274,13 @@ func (o *ReleaseOptions) GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration) 
 			// If no version was specified from the channel, then get the latest release
 			latest, err := GetLatestVersion(ch)
 			if err != nil {
-				return image.Associations{}, err
+				return nil, err
 			}
 			logrus.Infof("Image to download: %v", latest.Image)
 			// Download the release
 			assocs, err := o.downloadMirror([]byte(pullSecret), srcDir, latest.Image)
 			if err != nil {
-				return image.Associations{}, err
+				return nil, err
 			}
 			allAssocs.Merge(assocs)
 			logrus.Infof("Channel Latest version %v", latest.Version)
@@ -288,19 +293,19 @@ func (o *ReleaseOptions) GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration) 
 			ver, err := semver.Parse(v)
 
 			if err != nil {
-				return image.Associations{}, err
+				return nil, err
 			}
 
 			// This dumps the available upgrades from the last downloaded version
 			requested, _, err := calculateUpgradePath(ch, ver)
 			if err != nil {
-				return image.Associations{}, fmt.Errorf("failed to get upgrade graph: %v", err)
+				return nil, fmt.Errorf("failed to get upgrade graph: %v", err)
 			}
 
 			logrus.Infof("requested: %v", requested.Version)
 			assocs, err := o.downloadMirror([]byte(pullSecret), srcDir, requested.Image)
 			if err != nil {
-				return image.Associations{}, err
+				return nil, err
 			}
 			allAssocs.Merge(assocs)
 			logrus.Infof("Channel Latest version %v", requested.Version)
@@ -335,7 +340,7 @@ func (o *ReleaseOptions) GetReleasesInitial(cfg v1alpha1.ImageSetConfiguration) 
 
 func (o *ReleaseOptions) GetReleasesDiff(_ v1alpha1.PastMirror, cfg v1alpha1.ImageSetConfiguration) (image.Associations, error) {
 
-	allAssocs := image.Associations{}
+	allAssocs := image.NewAssociations()
 	pullSecret := cfg.Mirror.OCP.PullSecret
 	srcDir := filepath.Join(o.Dir, config.SourceDir)
 
@@ -347,19 +352,19 @@ func (o *ReleaseOptions) GetReleasesDiff(_ v1alpha1.PastMirror, cfg v1alpha1.Ima
 			ver, err := semver.Parse(v)
 
 			if err != nil {
-				return image.Associations{}, err
+				return nil, err
 			}
 
 			// This dumps the available upgrades from the last downloaded version
 			requested, _, err := calculateUpgradePath(ch, ver)
 			if err != nil {
-				return image.Associations{}, fmt.Errorf("failed to get upgrade graph: %v", err)
+				return nil, fmt.Errorf("failed to get upgrade graph: %v", err)
 			}
 
 			logrus.Infof("requested: %v", requested.Version)
 			assocs, err := o.downloadMirror([]byte(pullSecret), srcDir, requested.Image)
 			if err != nil {
-				return image.Associations{}, err
+				return nil, err
 			}
 			allAssocs.Merge(assocs)
 
@@ -394,6 +399,8 @@ func (o *ReleaseOptions) GetReleasesDiff(_ v1alpha1.PastMirror, cfg v1alpha1.Ima
 }
 
 // getMapping will run release mirror with ToMirror set to true to get mapping information
+// FIXME(jpower): the provided mapping does not provide a digest mapping so ICSP cannot
+// be created
 func (o *ReleaseOptions) getMapping(opts release.MirrorOptions) (mappings map[string]string, images []string, err error) {
 
 	mappingPath := filepath.Join(o.Dir, "release-mapping.txt")
@@ -423,6 +430,11 @@ func (o *ReleaseOptions) getMapping(opts release.MirrorOptions) (mappings map[st
 		text := scanner.Text()
 		split := strings.Split(text, " ")
 
+		// Get release image name from mapping
+		if strings.Contains(split[0], "ocp-release") {
+			o.release = split[0]
+		}
+
 		// Proccess name and add arch to dir name
 		// TODO: architecture handling
 		var names []string
@@ -435,6 +447,7 @@ func (o *ReleaseOptions) getMapping(opts release.MirrorOptions) (mappings map[st
 		if _, err := file.WriteString(split[0] + "=" + name + "\n"); err != nil {
 			return mappings, images, err
 		}
+
 		images = append(images, split[0])
 	}
 

--- a/pkg/operator/mirror.go
+++ b/pkg/operator/mirror.go
@@ -103,7 +103,7 @@ func (o *MirrorOptions) Full(ctx context.Context, cfg v1alpha1.ImageSetConfigura
 	}
 	defer reg.Destroy()
 
-	allAssocs := image.Associations{}
+	allAssocs := image.NewAssociations()
 	for _, ctlg := range cfg.Mirror.Operators {
 		ctlgRef, err := imagesource.ParseReference(ctlg.Catalog)
 		if err != nil {
@@ -168,7 +168,7 @@ func (o *MirrorOptions) Diff(ctx context.Context, cfg v1alpha1.ImageSetConfigura
 	}
 	defer reg.Destroy()
 
-	allAssocs := image.Associations{}
+	allAssocs := image.NewAssociations()
 	for _, ctlg := range cfg.Mirror.Operators {
 		// Generate and mirror a heads-only diff using the catalog as a new ref,
 		// and an old ref found for this catalog in lastRun.
@@ -411,8 +411,9 @@ func (o *MirrorOptions) associateDeclarativeConfigImageLayers(ctlgRef imagesourc
 	}
 
 	srcDir := filepath.Join(o.Dir, config.SourceDir)
+
 	associateWithType := func(mappings map[string]string, images []string, typ image.ImageType) error {
-		assocs, err := image.AssociateImageLayers(srcDir, mappings, images)
+		assocs, err := image.AssociateImageLayers(srcDir, mappings, images, typ)
 		if err != nil {
 			merr := &image.ErrNoMapping{}
 			cerr := &image.ErrInvalidComponent{}
@@ -424,13 +425,6 @@ func (o *MirrorOptions) associateDeclarativeConfigImageLayers(ctlgRef imagesourc
 			o.Logger.Warn(err)
 		}
 
-		for k, assoc := range assocs {
-			if assoc.Name == ctlgRef.Ref.Exact() {
-				assoc.TopLevel = true
-			}
-			assoc.Type = typ
-			assocs[k] = assoc
-		}
 		allAssocs.Merge(assocs)
 
 		return nil

--- a/pkg/operator/mirror.go
+++ b/pkg/operator/mirror.go
@@ -86,7 +86,7 @@ func (o *MirrorOptions) createRegistry() (*containerdregistry.Registry, error) {
 }
 
 // Full mirrors each catalog image in its entirety to the <Dir>/src directory.
-func (o *MirrorOptions) Full(ctx context.Context, cfg v1alpha1.ImageSetConfiguration) (image.Associations, error) {
+func (o *MirrorOptions) Full(ctx context.Context, cfg v1alpha1.ImageSetConfiguration) (image.AssociationSet, error) {
 	o.complete()
 
 	cleanup, err := o.mktempDir()
@@ -103,7 +103,7 @@ func (o *MirrorOptions) Full(ctx context.Context, cfg v1alpha1.ImageSetConfigura
 	}
 	defer reg.Destroy()
 
-	allAssocs := image.NewAssociations()
+	allAssocs := image.AssociationSet{}
 	for _, ctlg := range cfg.Mirror.Operators {
 		ctlgRef, err := imagesource.ParseReference(ctlg.Catalog)
 		if err != nil {
@@ -151,7 +151,7 @@ func (o *MirrorOptions) Full(ctx context.Context, cfg v1alpha1.ImageSetConfigura
 
 // Diff mirrors only the diff between each old and new catalog image pair
 // to the <Dir>/src directory.
-func (o *MirrorOptions) Diff(ctx context.Context, cfg v1alpha1.ImageSetConfiguration, lastRun v1alpha1.PastMirror) (image.Associations, error) {
+func (o *MirrorOptions) Diff(ctx context.Context, cfg v1alpha1.ImageSetConfiguration, lastRun v1alpha1.PastMirror) (image.AssociationSet, error) {
 	o.complete()
 
 	cleanup, err := o.mktempDir()
@@ -168,7 +168,7 @@ func (o *MirrorOptions) Diff(ctx context.Context, cfg v1alpha1.ImageSetConfigura
 	}
 	defer reg.Destroy()
 
-	allAssocs := image.NewAssociations()
+	allAssocs := image.AssociationSet{}
 	for _, ctlg := range cfg.Mirror.Operators {
 		// Generate and mirror a heads-only diff using the catalog as a new ref,
 		// and an old ref found for this catalog in lastRun.
@@ -400,7 +400,7 @@ func isMappingFile(p string) bool {
 	return filepath.Base(p) == mappingFile
 }
 
-func (o *MirrorOptions) associateDeclarativeConfigImageLayers(ctlgRef imagesource.TypedImageReference, dc *declcfg.DeclarativeConfig, allAssocs image.Associations) error {
+func (o *MirrorOptions) associateDeclarativeConfigImageLayers(ctlgRef imagesource.TypedImageReference, dc *declcfg.DeclarativeConfig, allAssocs image.AssociationSet) error {
 
 	var bundleImages, relatedImages []string
 	for _, b := range dc.Bundles {


### PR DESCRIPTION
- Changes to associations allow for process images and all of the associations values one at a time.
- Releases are kept together by updating the key to the release image after gathering the associations
- Added cleanup actions to archiver