### PR TITLE
feat(operators): rebuild, push catalog images during publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,72 @@
 # Bundle
 
-# Development!
+**This repo is under active development. CLI and APIs are unstable**
 
-This repo is being developed.
+Bundle is an OpenShift Client (oc) plugin that manages OpenShift release, operator catalog, and associated container images.
+
+Bundle management is a two part process:
+1. Bundle Creation (Internet Connected)
+1. Bundle Publishing (Disconnected)
+
+## Requirements
+
+- [`docker buildx`][docker-buildx] (called by `publish`)
+
+## Usage
+
+The mirror registry `reg.mirror.com` is used in this example.
+Replace this value with a real registry host, or create a `docker.io/library/registry:2` container locally.
+
+1. Download pull secret and place at ~/.docker/config.json
+    - This should contain auth config for both release/catalog source images _and_ your mirror registry.
+1. Build:
+    ```sh
+    make build
+    ```
+1. Create then publish to your mirror registry:
+    ```sh
+    ./bin/oc-bundle create full --config imageset-config.yaml --dir test-create --output archives --log-level debug
+    ./bin/oc-bundle publish --archive archives --dir test-publish --to-mirror reg.mirror.com
+    ```
+
+For configuration and options, see the [expanded overview](./docs/overview.md) and [usage](./docs/usage.md) docs.
+
+## Bundle Spec
+
+See the [config spec][config-spec] for an in-depth description of fields.
+
+**Note:** The `imageset-config.yaml` is only used during bundle creation.
+
+## Development
+
+### Requirements
+
+- All top-level requirements
+- [`go`][go] version 1.16+
 
 ### Build
 
-Not automated yet.
-
-Requires go version 1.16.
-
-Manual Build:
-```
+```sh
 make
 ./bin/oc-bundle -h
 ```
 
 ### Test
 
-Manual Unit Tests:
-```bash
+Unit:
+```sh
 make test-unit
 ```
 
-Manual E2E:
-```bash
+E2E:
+```sh
 make test-e2e
 ```
-
-
-Function test:
-1. Download pull secret and place at ~/.docker/config.json
-2. Build and test:
-  ```sh
-  mkdir -p test-output/src/publish
-  cp data/imageset-config.yaml test-output/
-  cp data/.metadata.json test-output/src/publish
-  make
-  ./bin/oc-bundle create full --config imageset-config.yaml --dir=test-output --log-level=debug
-  ```
-
-## Overview
-
-Bundle is an OpenShift Client (oc) plugin that manages OpenShift installation, operator, and associated container images.
-
-Bundle management is a two part process:
-
-Part 1: Bundle Creation (Internet Connected)
-Part 2: Bundle Publishing (Disconnected)
-
-## Usage
-
-See docs for [expanded overview](./docs/overview.md) and [basic usage information](./docs/usage.md)
-
-## Bundle Spec
-
-Note: The `imageset-config.yaml` is only used during bundle creation.
-
-See the [config spec][config-spec] for an in-depth description of fields.
 
 <!--
 TODO: link to the following once a release is cut.
 [config-spec]:https://pkg.go.dev/github.com/redhatgov/bundle/pkg/config/v1alpha1#ImageSetConfiguration
 -->
 [config-spec]:pkg/config/v1alpha1/config_types.go
+[go]:https://golang.org/dl/
+[docker-buildx]:https://docs.docker.com/buildx/working-with-buildx/

--- a/pkg/bundle/additional.go
+++ b/pkg/bundle/additional.go
@@ -2,7 +2,6 @@ package bundle
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
@@ -57,12 +56,8 @@ func (o *AdditionalOptions) GetAdditional(_ v1alpha1.PastMirror, cfg v1alpha1.Im
 		}
 
 		// Set destination image information
-		pathRef := "file://" + img.Name
-
-		dstRef, err := imagesource.ParseReference(pathRef)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing destination reference %s: %v", pathRef, err)
-		}
+		dstRef := srcRef
+		dstRef.Type = imagesource.DestinationFile
 		dstRef.Ref = dstRef.Ref.DockerClientDefaults()
 
 		// Check if image is specified as a blocked image
@@ -78,8 +73,10 @@ func (o *AdditionalOptions) GetAdditional(_ v1alpha1.PastMirror, cfg v1alpha1.Im
 
 		// Add mapping and image for image association.
 		// The registry component is not included in the final path.
-		assocMappings[srcRef.String()] = "file://" + path.Join(dstRef.Ref.Namespace, dstRef.Ref.NameString())
-		images[i] = srcRef.String()
+		srcImage := srcRef.Ref.String()
+		dstRef.Ref.Registry = ""
+		assocMappings[srcImage] = dstRef.String()
+		images[i] = srcImage
 	}
 
 	opts.Mappings = mappings

--- a/pkg/bundle/create/create.go
+++ b/pkg/bundle/create/create.go
@@ -126,6 +126,7 @@ func (o *Options) RunDiff(ctx context.Context) error {
 
 		if len(cfg.Mirror.Operators) != 0 {
 			opts := operator.NewMirrorOptions(*o.RootOptions)
+			opts.SkipImagePin = o.SkipImagePin
 			assocs, err := opts.Diff(ctx, cfg, lastRun)
 			if err != nil {
 				return meta, run, err
@@ -165,6 +166,13 @@ func (o *Options) create(ctx context.Context, f createFunc) error {
 	if err != nil {
 		return err
 	}
+
+	// Make sure the `opm` image exists during the publish step
+	// since catalog images need to be rebuilt.
+	// TODO(estroz): vet that this is the correct image, and version correctly.
+	cfg.Mirror.AdditionalImages = append(cfg.Mirror.AdditionalImages, v1alpha1.AdditionalImages{
+		Image: v1alpha1.Image{Name: "quay.io/operator-framework/opm:latest"},
+	})
 
 	// Validating user path input
 	if err := o.ValidatePaths(); err != nil {

--- a/pkg/bundle/create/options.go
+++ b/pkg/bundle/create/options.go
@@ -11,13 +11,15 @@ import (
 type Options struct {
 	*cli.RootOptions
 
-	OutputDir  string
-	ConfigPath string
+	OutputDir    string
+	ConfigPath   string
+	SkipImagePin bool
 }
 
 func (o *Options) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.ConfigPath, "config", "c", "imageset-config.yaml", "Path to imageset configuration file")
 	fs.StringVarP(&o.OutputDir, "output", "o", ".", "output directory for archives")
+	fs.BoolVar(&o.SkipImagePin, "skip-image-pin", false, "Do not replace image tags with digest pins in operator catalogs")
 }
 
 // ValidatePaths validate the existence of paths from user flags

--- a/pkg/bundle/publish/catalog_images.go
+++ b/pkg/bundle/publish/catalog_images.go
@@ -1,0 +1,178 @@
+package publish
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
+	"github.com/operator-framework/operator-registry/alpha/action"
+	"github.com/operator-framework/operator-registry/alpha/declcfg"
+	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
+	"github.com/sirupsen/logrus"
+)
+
+func (o *Options) rebuildCatalogs(ctx context.Context, dstDir string, filesInArchive map[string]string) (refs []imagesource.TypedImageReference, err error) {
+	if err := unpack("catalogs", dstDir, filesInArchive); err != nil {
+		return nil, err
+	}
+
+	mirrorRef := imagesource.TypedImageReference{Type: imagesource.DestinationRegistry}
+	if mirrorRef.Ref, err = reference.Parse(o.ToMirror); err != nil {
+		return nil, err
+	}
+
+	dstDir = filepath.Clean(dstDir)
+	catalogsByImage := map[imagesource.TypedImageReference]string{}
+	if err := filepath.Walk(dstDir, func(fpath string, info fs.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return err
+		}
+
+		slashPath := filepath.ToSlash(fpath)
+		if base := path.Base(slashPath); base == "index.json" {
+			slashPath = strings.TrimPrefix(slashPath, fmt.Sprintf("%s/catalogs/", dstDir))
+			regRepoNs, id := path.Split(path.Dir(slashPath))
+			regRepoNs = path.Clean(regRepoNs)
+			var img string
+			if strings.Contains(id, ":") {
+				// Digest.
+				img = fmt.Sprintf("%s@%s", regRepoNs, id)
+			} else {
+				// Tag.
+				img = fmt.Sprintf("%s:%s", regRepoNs, id)
+			}
+			ctlgRef := imagesource.TypedImageReference{Type: imagesource.DestinationRegistry}
+			if ctlgRef.Ref, err = reference.Parse(img); err != nil {
+				return fmt.Errorf("error parsing index dir path %q as image %q: %v", fpath, img, err)
+			}
+			// Update registry so the existing catalog image can be pulled.
+			// QUESTION(estroz): is assuming an image is present in a repo with the same name valid?
+			ctlgRef.Ref.Registry = mirrorRef.Ref.Registry
+			catalogsByImage[ctlgRef] = filepath.Dir(fpath)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	resolver, err := containerdregistry.NewResolver("", o.SkipTLS, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating image resolver: %v", err)
+	}
+	reg, err := containerdregistry.NewRegistry(
+		containerdregistry.SkipTLS(o.SkipTLS),
+		containerdregistry.WithCacheDir(filepath.Join(dstDir, "cache")),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer reg.Destroy()
+	for ctlgRef, dcDir := range catalogsByImage {
+
+		// An image for a particular catalog may not exist in the mirror registry yet,
+		// ex. when publish is run for the first time for a catalog (full/headsonly).
+		// If that is the case, then simply build the catalog image with the new
+		// declarative config catalog; otherwise render the existing and new catalogs together.
+		var dcDirToBuild string
+		refExact := ctlgRef.Ref.Exact()
+		if _, _, rerr := resolver.Resolve(ctx, refExact); rerr == nil {
+
+			logrus.Infof("Catalog image %q found, rendering with new file-based catalog", refExact)
+
+			dc, err := action.Render{
+				// Order the old ctlgRef before dcDir so new packages/channels/bundles overwrite
+				// existing counterparts.
+				Refs:           []string{refExact, dcDir},
+				AllowedRefMask: action.RefAll,
+				Registry:       reg,
+			}.Run(ctx)
+			if err != nil {
+				return nil, err
+			}
+			dcDirToBuild = filepath.Join(dcDir, "rendered")
+			if err := os.MkdirAll(dcDirToBuild, os.ModePerm); err != nil {
+				return nil, err
+			}
+			renderedPath := filepath.Join(dcDirToBuild, "index.json")
+			f, err := os.Create(renderedPath)
+			if err != nil {
+				return nil, err
+			}
+			defer f.Close()
+			if err := declcfg.WriteJSON(*dc, f); err != nil {
+				return nil, err
+			}
+
+		} else if errors.Is(rerr, errdefs.ErrNotFound) {
+
+			logrus.Infof("Catalog image %q not found, using new file-based catalog", refExact)
+			dcDirToBuild = dcDir
+
+		} else {
+			return nil, fmt.Errorf("error resolving existing catalog image %q: %v", refExact, rerr)
+		}
+
+		// Build and push a new image with the same namespace, name, and optionally tag
+		// as the original image, but to the mirror.
+		if err := o.buildCatalogImage(ctx, ctlgRef.Ref, dcDirToBuild); err != nil {
+			return nil, fmt.Errorf("error building catalog image %q: %v", ctlgRef.Ref.Exact(), err)
+		}
+
+		// Resolve the image's digest for ICSP creation.
+		_, desc, err := resolver.Resolve(ctx, ctlgRef.Ref.Exact())
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving digest for catalog image %q: %v", ctlgRef.Ref.Exact(), err)
+		}
+		ctlgRef.Ref.ID = desc.Digest.String()
+
+		refs = append(refs, ctlgRef)
+	}
+
+	return refs, nil
+}
+
+func (o *Options) buildCatalogImage(ctx context.Context, ref reference.DockerImageReference, dir string) error {
+	dockerfile := filepath.Join(dir, "index.Dockerfile")
+	f, err := os.Create(dockerfile)
+	if err != nil {
+		return err
+	}
+	if err := (action.GenerateDockerfile{
+		// TODO(estroz): handle this image as an additional image, and version it.
+		// Is this image fq name correct? It will work without an ICSP because
+		// the mirror == its registry, but will tags be handled correctly by
+		// the container distribution layer?
+		BaseImage: o.ToMirror + "/operator-framework/opm:latest",
+		IndexDir:  ".",
+		Writer:    f,
+	}).Run(); err != nil {
+		return err
+	}
+
+	logrus.Infof("Building rendered catalog image: %s", ref.Exact())
+
+	args := []string{
+		"buildx", "build",
+		"-t", ref.Exact(),
+		"-f", dockerfile,
+		"--platform", strings.Join(o.CatalogPlatforms, ","),
+		"--push",
+		dir,
+	}
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	logrus.Debugf("command: %s", strings.Join(cmd.Args, " "))
+
+	return cmd.Run()
+}

--- a/pkg/bundle/publish/options.go
+++ b/pkg/bundle/publish/options.go
@@ -11,15 +11,18 @@ import (
 type Options struct {
 	*cli.RootOptions
 
-	ArchivePath string
-	ToMirror    string
-
-	tmp string
+	ArchivePath      string
+	ToMirror         string
+	CatalogPlatforms []string
 }
+
+var defaultPlatforms = []string{"linux/amd64"}
 
 func (o *Options) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ArchivePath, "archive", "", "The archive file path.")
 	fs.StringVar(&o.ToMirror, "to-mirror", "", "The URL to the destination mirror registry")
+	fs.StringSliceVar(&o.CatalogPlatforms, "catalog-platforms", defaultPlatforms, "Platforms to build a catalog manifest list for. "+
+		"This list does NOT filter operator bundle manifest list platforms within the catalog")
 }
 
 // ValidatePaths validate the existence of paths from user flags

--- a/pkg/image/association.go
+++ b/pkg/image/association.go
@@ -14,7 +14,6 @@ import (
 
 	ctrsimgmanifest "github.com/containers/image/v5/manifest"
 	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -266,7 +265,6 @@ func ReadImageMapping(mappingsPath string) (map[string]string, error) {
 		if len(split) != 2 {
 			return nil, fmt.Errorf("mapping %q expected to have exactly one \"=\"", text)
 		}
-		logrus.Debugf("read mapping: %s=%s", split[0], split[1])
 		mappings[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
 	}
 

--- a/test/e2e-simple.sh
+++ b/test/e2e-simple.sh
@@ -29,8 +29,9 @@ run_cmd create full --dir "$CREATE_FULL_DIR" --config "${CREATE_FULL_DIR}/images
 "${DIR}/stop-docker-registry.sh" $REGISTRY_CONN
 "${DIR}/start-docker-registry.sh" $REGISTRY_DISCONN $REGISTRY_DISCONN_PORT
 run_cmd publish --dir "$PUBLISH_FULL_DIR" --archive "${DATA_TMP}/bundle_000000.tar" --to-mirror localhost:$REGISTRY_DISCONN_PORT
-check_bundles "${PUBLISH_FULL_DIR}/catalogs/localhost:${REGISTRY_CONN_PORT}/test-catalogs/test-catalog/latest-index.json" \
-  "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1"
+check_bundles localhost:${REGISTRY_DISCONN_PORT}/test-catalogs/test-catalog:latest \
+  "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.0.0 baz.v1.0.1 baz.v1.1.0 foo.v0.1.0 foo.v0.2.0 foo.v0.3.0 foo.v0.3.1" \
+  localhost:${REGISTRY_DISCONN_PORT}
 "${DIR}/stop-docker-registry.sh" $REGISTRY_DISCONN
 rm -rf "$DATA_TMP"
 
@@ -42,8 +43,9 @@ run_cmd create full --dir "$CREATE_FULL_DIR" --config "${CREATE_FULL_DIR}/images
 "${DIR}/stop-docker-registry.sh" $REGISTRY_CONN
 "${DIR}/start-docker-registry.sh" $REGISTRY_DISCONN $REGISTRY_DISCONN_PORT
 run_cmd publish --dir "$PUBLISH_FULL_DIR" --archive "${DATA_TMP}/bundle_000000.tar" --to-mirror localhost:$REGISTRY_DISCONN_PORT
-check_bundles "${PUBLISH_FULL_DIR}/catalogs/localhost:${REGISTRY_CONN_PORT}/test-catalogs/test-catalog/latest-index.json" \
-  "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1"
+check_bundles localhost:${REGISTRY_DISCONN_PORT}/test-catalogs/test-catalog:latest \
+  "bar.v0.1.0 bar.v0.2.0 bar.v1.0.0 baz.v1.1.0 foo.v0.3.1" \
+  localhost:${REGISTRY_DISCONN_PORT}
 "${DIR}/stop-docker-registry.sh" $REGISTRY_DISCONN
 rm -rf "$DATA_TMP"
 

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -11,26 +11,45 @@ function run_cmd() {
   "$CMD" $@ $test_flags
 }
 
-# check_bundles ensures the number and names of bundles in index_path
-# matches that of exp_bundles_list.
+# check_bundles ensures the number and names of bundles in catalog_image's index.json
+# matches that of exp_bundles_list, and that all bundle images are pullable.
 function check_bundles() {
-  local index_path="${1:?index path required}"
+  local catalog_image="${1:?catalog image required}"
   local exp_bundles_list="${2:?expected bundles list must be set}"
+  local disconn_registry="${3:?disconnected registry host name must be set}"
+
+  docker pull $catalog_image
+  local container=$(docker create $catalog_image)
+  local index_dir="${DATA_TMP}/unpacked"
+  mkdir -p "$index_dir"
+  local index_path="${index_dir}/index.json"
+  docker cp ${container}:/configs/index.json "$index_path"
+
   declare -A exp_bundles_set
   for bundle in $exp_bundles_list; do
     exp_bundles_set[$bundle]=bundle
   done
-  local index_bundles=$(cat "$index_path" | jq -sr '.[] | select(.schema == "olm.bundle") | .name')
 
   # Ensure the number of bundles matches.
-  local num_bundles=$(echo $index_bundles | wc -w)
+  local index_bundle_names=$(cat "$index_path" | jq -sr '.[] | select(.schema == "olm.bundle") | .name')
+  local num_bundles=$(echo $index_bundle_names | wc -w)
   if (( ${#exp_bundles_set[@]} != $num_bundles )); then
     echo "number of bundles mirrored (${#exp_bundles_set[@]}) does not match expected number (${num_bundles})"
     return 1
   fi
 
+  # Ensure all bundle images are pullable.
+  local index_bundle_images=$(cat "$index_path" | jq -sr '.[] | select(.schema == "olm.bundle") | .image')
+  for image in $index_bundle_images; do
+    image=${disconn_registry}/$(echo $image | cut --complement -d'/' -f1)
+    if ! docker pull $image; then
+      echo "bundle image $image not pushed to registry"
+      return 1
+    fi
+  done
+
   # Ensure each bundle is an expected bundle.
-  for bundle in $index_bundles; do
+  for bundle in $index_bundle_names; do
     if [[ "${exp_bundles_set[$bundle]}" != "bundle" ]]; then
       echo "bundle $bundle not in expected bundle set"
       return 1


### PR DESCRIPTION
See #85 for details. An important implementation detail: catalog images themselves are no longer mirrored in `create`. Instead the images specified in the file-based catalog (DC) packaged into archive(s) are mirrored and treated as generic images, and `publish` will build and push catalog image directly using `docker buildx build --push`.

Closes #85

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>