### PR TITLE
feat(publish): optionally use 'docker buildx build' for multi-arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,14 @@ Bundle management is a two part process:
 1. Bundle Creation (Internet Connected)
 1. Bundle Publishing (Disconnected)
 
-## Requirements
+## Required dependencies
 
-- [`docker buildx`][docker-buildx] (called by `publish`)
+- [`podman`][podman] (only required if not building multi-arch images, see below)
+
+## Multi-arch catalog images
+
+[`docker buildx`][docker-buildx] is required to build multi-arch catalog images;
+`docker buildx build` is invoked by `publish` when `--buildx-platforms` is set.
 
 ## Usage
 
@@ -73,3 +78,4 @@ TODO: link to the following once a release is cut.
 [config-spec]:pkg/config/v1alpha1/config_types.go
 [go]:https://golang.org/dl/
 [docker-buildx]:https://docs.docker.com/buildx/working-with-buildx/
+[podman]:https://podman.io/getting-started/

--- a/pkg/bundle/publish/catalog_images_test.go
+++ b/pkg/bundle/publish/catalog_images_test.go
@@ -65,10 +65,6 @@ func Test_buildCatalogImage(t *testing.T) {
 				SkipTLS: true,
 			},
 			ArchivePath: tt.fields.archivePath,
-			CatalogPlatforms: []string{
-				"linux/amd64",
-				"linux/arm64",
-			},
 		}
 
 		ref := reference.DockerImageReference{

--- a/pkg/bundle/publish/options.go
+++ b/pkg/bundle/publish/options.go
@@ -11,18 +11,20 @@ import (
 type Options struct {
 	*cli.RootOptions
 
-	ArchivePath      string
-	ToMirror         string
-	CatalogPlatforms []string
-}
+	ArchivePath string
+	ToMirror    string
 
-var defaultPlatforms = []string{"linux/amd64"}
+	BuildxPlatforms []string
+}
 
 func (o *Options) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ArchivePath, "archive", "", "The archive file path.")
 	fs.StringVar(&o.ToMirror, "to-mirror", "", "The URL to the destination mirror registry")
-	fs.StringSliceVar(&o.CatalogPlatforms, "catalog-platforms", defaultPlatforms, "Platforms to build a catalog manifest list for. "+
-		"This list does NOT filter operator bundle manifest list platforms within the catalog")
+	fs.StringSliceVar(&o.BuildxPlatforms, "buildx-platforms", nil,
+		"If set, the command will invoke 'docker buildx build' to build a catalog manifest list "+
+			"for the specified platforms, ex. linux/amd64, instead of 'podman build' for the host platform. "+
+			"The 'buildx' plugin and accompanying configuration MUST be installed on the build host. "+
+			"This list does NOT filter operator bundle manifest list platforms within the catalog")
 }
 
 // ValidatePaths validate the existence of paths from user flags


### PR DESCRIPTION
Made some stuff removed in #108 an optional feature, so those who do want multi-arch have an escape hatch.

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>